### PR TITLE
Opt-in parallel processing of all messages in SQS response.

### DIFF
--- a/Rock.Messaging.SQS/Configuration/ISQSConfiguration.cs
+++ b/Rock.Messaging.SQS/Configuration/ISQSConfiguration.cs
@@ -11,6 +11,7 @@ namespace Rock.Messaging.SQS
         int MaxMessages { get; set; }
         bool AutoAcknowledge { get; }
         bool Compressed { get; }
+        bool ParallelHandling { get; }
         void Validate();
     }
 }

--- a/Rock.Messaging.SQS/Configuration/SQSConfiguration.cs
+++ b/Rock.Messaging.SQS/Configuration/SQSConfiguration.cs
@@ -8,6 +8,7 @@ namespace RockLib.Messaging.SQS
         {
             MaxMessages = 3;
             AutoAcknowledge = true;
+            ParallelHandling = false;
         }
 
         public string Name { get; set; }
@@ -15,6 +16,7 @@ namespace RockLib.Messaging.SQS
         public int MaxMessages { get; set; }
         public bool AutoAcknowledge { get; set; }
         public bool Compressed { get; set; }
+        public bool ParallelHandling { get; set; }
 
         public void Validate()
         {

--- a/Rock.Messaging.SQS/Configuration/SQSConfiguration.cs
+++ b/Rock.Messaging.SQS/Configuration/SQSConfiguration.cs
@@ -8,7 +8,6 @@ namespace RockLib.Messaging.SQS
         {
             MaxMessages = 3;
             AutoAcknowledge = true;
-            ParallelHandling = false;
         }
 
         public string Name { get; set; }

--- a/Rock.Messaging.SQS/MQ/SQSQueueReceiver.cs
+++ b/Rock.Messaging.SQS/MQ/SQSQueueReceiver.cs
@@ -77,7 +77,7 @@ namespace Rock.Messaging.SQS
                 ReceiveMessageResponse response = null;
                 Exception exception = null;
 
-                for (int i = 0; i < _maxAcknowledgeAttempts; i++)
+                for (int i = 0; i < _maxReceiveAttempts; i++)
                 {
                     try
                     {
@@ -142,7 +142,7 @@ namespace Rock.Messaging.SQS
                         Exception deleteException = null;
                         DeleteMessageResponse deleteResponse = null;
 
-                        for (int i = 0; i < 3; i++)
+                        for (int i = 0; i < _maxAcknowledgeAttempts; i++)
                         {
                             try
                             {

--- a/Rock.Messaging.SQS/MQ/SQSQueueReceiver.cs
+++ b/Rock.Messaging.SQS/MQ/SQSQueueReceiver.cs
@@ -114,7 +114,7 @@ namespace Rock.Messaging.SQS
                 {
                     foreach (var message in response.Messages)
                     {
-                        this.Handle(message);
+                        Handle(message);
                     }
                 }
             }

--- a/Rock.Messaging.SQS/MQ/SQSQueueReceiver.cs
+++ b/Rock.Messaging.SQS/MQ/SQSQueueReceiver.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 
 #if ROCKLIB
 using System.Diagnostics;
@@ -19,8 +20,6 @@ namespace RockLib.Messaging.SQS
 namespace Rock.Messaging.SQS
 #endif
 {
-    using System.Threading.Tasks;
-
     public class SQSQueueReceiver : IReceiver
     {
         private readonly string _name;
@@ -112,7 +111,7 @@ namespace Rock.Messaging.SQS
                     Parallel.ForEach(response.Messages, Handle);
                 }
                 else
-                { 
+                {
                     foreach (var message in response.Messages)
                     {
                         this.Handle(message);

--- a/Rock.Messaging.SQS/MQ/SQSQueueReceiver.cs
+++ b/Rock.Messaging.SQS/MQ/SQSQueueReceiver.cs
@@ -32,6 +32,9 @@ namespace Rock.Messaging.SQS
 
         private bool _stopped;
 
+        private const int _maxAcknowledgeAttempts = 3;
+        private const int _maxReceiveAttempts = 3;
+
         public SQSQueueReceiver(ISQSConfiguration configuration, IAmazonSQS sqs)
         {
             _name = configuration.Name;
@@ -74,7 +77,7 @@ namespace Rock.Messaging.SQS
                 ReceiveMessageResponse response = null;
                 Exception exception = null;
 
-                for (int i = 0; i < 3; i++)
+                for (int i = 0; i < _maxAcknowledgeAttempts; i++)
                 {
                     try
                     {

--- a/Rock.Messaging.SQS/RockLib.Messaging.SQS.csproj
+++ b/Rock.Messaging.SQS/RockLib.Messaging.SQS.csproj
@@ -48,6 +48,7 @@
     <ItemGroup>
       <PackageReference Include="AWSSDK.SQS" Version="3.3.3" />
       <PackageReference Include="RockLib.Messaging" Version="0.0.1-alpha01" />
+      <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Added config setting ParallelHandling, defaulted to false
- Switch parallel looping through SQS ``response.Messages`` on ParallelHandling setting