### PR TITLE
Update example sqs projects to use latest nuget

### DIFF
--- a/Example.Messaging.DotNetFramework451/Example.Messaging.DotNetFramework451.csproj
+++ b/Example.Messaging.DotNetFramework451/Example.Messaging.DotNetFramework451.csproj
@@ -39,9 +39,6 @@
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.1.1.2\lib\netstandard1.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.1.1.2\lib\netstandard1.1\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.1.1.2\lib\net451\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
@@ -50,9 +47,6 @@
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration.Json, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.Json.1.1.2\lib\net451\Microsoft.Extensions.Configuration.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Xml, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Xml.1.1.2\lib\net451\Microsoft.Extensions.Configuration.Xml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.1.1.1\lib\netstandard1.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
@@ -65,9 +59,6 @@
     </Reference>
     <Reference Include="Microsoft.Extensions.Primitives, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Primitives.1.1.1\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -91,77 +82,26 @@
       <HintPath>..\packages\RockLib.Threading.1.0.0\lib\net45\RockLib.Threading.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
-    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.ComponentModel.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ComponentModel.Primitives.4.3.0\lib\net45\System.ComponentModel.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ComponentModel.TypeConverter, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ComponentModel.TypeConverter.4.3.0\lib\net45\System.ComponentModel.TypeConverter.dll</HintPath>
-    </Reference>
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
-    </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.3.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Example.Messaging.DotNetFramework451/packages.config
+++ b/Example.Messaging.DotNetFramework451/packages.config
@@ -2,17 +2,14 @@
 <packages>
   <package id="Microsoft.Extensions.Configuration" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.1.2" targetFramework="net451" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.FileExtensions" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.Json" version="1.1.2" targetFramework="net451" />
-  <package id="Microsoft.Extensions.Configuration.Xml" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.FileProviders.Abstractions" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Extensions.FileProviders.Physical" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Extensions.Primitives" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
-  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="RockLib.Compression" version="1.0.0" targetFramework="net451" />
@@ -21,28 +18,18 @@
   <package id="RockLib.Immutable" version="1.0.0" targetFramework="net451" />
   <package id="RockLib.Messaging" version="1.0.0" targetFramework="net451" />
   <package id="RockLib.Threading" version="1.0.0" targetFramework="net451" />
-  <package id="System.AppContext" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
-  <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net451" />
-  <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net451" />
-  <package id="System.Console" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
-  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.IO" version="4.3.0" targetFramework="net451" />
-  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
   <package id="System.Linq" version="4.3.0" targetFramework="net451" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
@@ -51,21 +38,15 @@
   <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
-  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
   <package id="System.Threading" version="4.3.0" targetFramework="net451" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
-  <package id="System.Xml.XmlSerializer" version="4.3.0" targetFramework="net451" />
 </packages>

--- a/Example.Messaging.SQS.DotNetCore11/Example.Messaging.SQS.DotNetCore11.csproj
+++ b/Example.Messaging.SQS.DotNetCore11/Example.Messaging.SQS.DotNetCore11.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RockLib.Messaging.SQS" Version="0.0.1-alpha03" />
+    <PackageReference Include="RockLib.Messaging.SQS" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Example.Messaging.SQS.DotNetCore20/Example.Messaging.SQS.DotNetCore20.csproj
+++ b/Example.Messaging.SQS.DotNetCore20/Example.Messaging.SQS.DotNetCore20.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RockLib.Messaging.SQS" Version="0.0.1-alpha03" />
+    <PackageReference Include="RockLib.Messaging.SQS" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Example.Messaging.SQS.DotNetFramework451/Example.Messaging.SQS.DotNetFramework451.csproj
+++ b/Example.Messaging.SQS.DotNetFramework451/Example.Messaging.SQS.DotNetFramework451.csproj
@@ -45,9 +45,6 @@
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.1.1.2\lib\netstandard1.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.1.1.2\lib\netstandard1.1\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.1.1.2\lib\net451\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
     </Reference>
@@ -56,9 +53,6 @@
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration.Json, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.Json.1.1.2\lib\net451\Microsoft.Extensions.Configuration.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Xml, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Xml.1.1.2\lib\net451\Microsoft.Extensions.Configuration.Xml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.1.1.1\lib\netstandard1.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
@@ -72,14 +66,11 @@
     <Reference Include="Microsoft.Extensions.Primitives, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Primitives.1.1.1\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RockLib.Compression, Version=0.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RockLib.Compression.0.0.1-alpha01\lib\net45\RockLib.Compression.dll</HintPath>
+    <Reference Include="RockLib.Compression, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RockLib.Compression.1.0.0\lib\net45\RockLib.Compression.dll</HintPath>
     </Reference>
     <Reference Include="RockLib.Configuration, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RockLib.Configuration.1.0.0\lib\net451\RockLib.Configuration.dll</HintPath>
@@ -90,87 +81,36 @@
     <Reference Include="RockLib.Immutable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RockLib.Immutable.1.0.0\lib\net45\RockLib.Immutable.dll</HintPath>
     </Reference>
-    <Reference Include="RockLib.Messaging, Version=0.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RockLib.Messaging.0.0.1-alpha03\lib\net451\RockLib.Messaging.dll</HintPath>
+    <Reference Include="RockLib.Messaging, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RockLib.Messaging.1.0.0\lib\net451\RockLib.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="RockLib.Messaging.SQS, Version=0.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RockLib.Messaging.SQS.0.0.1-alpha03\lib\net451\RockLib.Messaging.SQS.dll</HintPath>
+    <Reference Include="RockLib.Messaging.SQS, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RockLib.Messaging.SQS.1.0.0\lib\net451\RockLib.Messaging.SQS.dll</HintPath>
     </Reference>
     <Reference Include="RockLib.Threading, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RockLib.Threading.1.0.0\lib\net45\RockLib.Threading.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
-    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.ComponentModel.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ComponentModel.Primitives.4.3.0\lib\net45\System.ComponentModel.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ComponentModel.TypeConverter, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ComponentModel.TypeConverter.4.3.0\lib\net45\System.ComponentModel.TypeConverter.dll</HintPath>
-    </Reference>
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
-    </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.3.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Example.Messaging.SQS.DotNetFramework451/packages.config
+++ b/Example.Messaging.SQS.DotNetFramework451/packages.config
@@ -4,48 +4,35 @@
   <package id="AWSSDK.SQS" version="3.3.3" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.1.2" targetFramework="net451" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.FileExtensions" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.Json" version="1.1.2" targetFramework="net451" />
-  <package id="Microsoft.Extensions.Configuration.Xml" version="1.1.2" targetFramework="net451" />
   <package id="Microsoft.Extensions.FileProviders.Abstractions" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Extensions.FileProviders.Physical" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Extensions.Primitives" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
-  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
-  <package id="RockLib.Compression" version="0.0.1-alpha01" targetFramework="net451" />
+  <package id="RockLib.Compression" version="1.0.0" targetFramework="net451" />
   <package id="RockLib.Configuration" version="1.0.0" targetFramework="net451" />
   <package id="RockLib.Configuration.ObjectFactory" version="1.0.0" targetFramework="net451" />
   <package id="RockLib.Immutable" version="1.0.0" targetFramework="net451" />
-  <package id="RockLib.Messaging" version="0.0.1-alpha03" targetFramework="net451" />
-  <package id="RockLib.Messaging.SQS" version="0.0.1-alpha03" targetFramework="net451" />
+  <package id="RockLib.Messaging" version="1.0.0" targetFramework="net451" />
+  <package id="RockLib.Messaging.SQS" version="1.0.0" targetFramework="net451" />
   <package id="RockLib.Threading" version="1.0.0" targetFramework="net451" />
-  <package id="System.AppContext" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
-  <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net451" />
-  <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net451" />
-  <package id="System.Console" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
-  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.IO" version="4.3.0" targetFramework="net451" />
-  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
   <package id="System.Linq" version="4.3.0" targetFramework="net451" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
@@ -54,22 +41,15 @@
   <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
-  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
   <package id="System.Threading" version="4.3.0" targetFramework="net451" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
-  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net451" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" requireReinstallation="true" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
-  <package id="System.Xml.XmlSerializer" version="4.3.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Also fix nuget warning from .net framework example projects by removing
and re-adding nuget packages.