### PR TITLE
 Embed license in nuget packages

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (C) 2015 Quicken Loans
+Copyright (C) 2015-2019 Quicken Loans
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/RockLib.Messaging.Http/RockLib.Messaging.Http.csproj
+++ b/RockLib.Messaging.Http/RockLib.Messaging.Http.csproj
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright 2018-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging http</PackageTags>
     <Version>1.0.0</Version>
@@ -22,6 +22,10 @@
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\RockLib.Messaging.Http.xml</DocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="RockLib.Messaging" Version="2.0.0" />

--- a/RockLib.Messaging.Http/RockLib.Messaging.Http.csproj
+++ b/RockLib.Messaging.Http/RockLib.Messaging.Http.csproj
@@ -13,7 +13,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
-    <Copyright>Copyright 2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
+    <Copyright>Copyright 2018-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging http</PackageTags>
     <Version>1.0.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/RockLib.Messaging.NamedPipes/RockLib.Messaging.NamedPipes.csproj
+++ b/RockLib.Messaging.NamedPipes/RockLib.Messaging.NamedPipes.csproj
@@ -13,7 +13,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
-    <Copyright>Copyright 2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
+    <Copyright>Copyright 2018-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging</PackageTags>
     <Version>2.0.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/RockLib.Messaging.NamedPipes/RockLib.Messaging.NamedPipes.csproj
+++ b/RockLib.Messaging.NamedPipes/RockLib.Messaging.NamedPipes.csproj
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright 2018-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging</PackageTags>
     <Version>2.0.0</Version>
@@ -22,6 +22,10 @@
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\RockLib.Messaging.NamedPipes.xml</DocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="RockLib.Messaging" Version="2.0.0" />

--- a/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
+++ b/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright 2018-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging sns</PackageTags>
     <Version>1.0.0</Version>
@@ -22,6 +22,10 @@
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\RockLib.Messaging.SNS.xml</DocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.12" />

--- a/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
+++ b/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
@@ -13,7 +13,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
-    <Copyright>Copyright 2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
+    <Copyright>Copyright 2018-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging sns</PackageTags>
     <Version>1.0.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
+++ b/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
@@ -13,7 +13,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
-    <Copyright>Copyright 2017-2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
+    <Copyright>Copyright 2017-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging sqs</PackageTags>
     <Version>2.0.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
+++ b/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright 2017-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging sqs</PackageTags>
     <Version>2.0.0</Version>
@@ -22,6 +22,10 @@
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\RockLib.Messaging.SQS.xml</DocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SQS" Version="3.3.3.48" />

--- a/RockLib.Messaging/RockLib.Messaging.csproj
+++ b/RockLib.Messaging/RockLib.Messaging.csproj
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright 2017-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging</PackageTags>
     <Version>2.0.0</Version>
@@ -22,6 +22,10 @@
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\RockLib.Messaging.xml</DocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="RockLib.Compression" Version="1.0.0" />

--- a/RockLib.Messaging/RockLib.Messaging.csproj
+++ b/RockLib.Messaging/RockLib.Messaging.csproj
@@ -13,7 +13,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/RockLib/RockLib.Messaging/blob/master/LICENSE.md</PackageLicenseUrl>
-    <Copyright>Copyright 2017-2018 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
+    <Copyright>Copyright 2017-2019 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging</PackageTags>
     <Version>2.0.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
Embedding the license in the nuget package itself is the new standard from Microsoft.

References:
- [The issue that introduced the feature to nuget](https://github.com/NuGet/Home/issues/4628)
- [The guidance from Microsoft](https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg#project-properties)