### PR TITLE
 SQSSender can set MessageGroupId and MessageDeduplicationId properties

### DIFF
--- a/RockLib.Messaging.SQS.Tests/SQSTests.cs
+++ b/RockLib.Messaging.SQS.Tests/SQSTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using Moq;
@@ -41,7 +42,7 @@ namespace RockLib.Messaging.SQS.Tests
 
             using (var receiver = new SQSReceiver(mockSqs.Object, "foo", "http://url.com/foo", autoAcknowledge: false))
             {
-                receiver.Start(m =>
+                receiver.Start(async m =>
                 {
                     receivedMessage = m.StringPayload;
                     quxHeader = m.Headers.GetValue<string>("qux");
@@ -74,9 +75,9 @@ namespace RockLib.Messaging.SQS.Tests
 
             using (var receiver = new SQSReceiver(mockSqs.Object, "foo", "http://url.com/foo", autoAcknowledge: false))
             {
-                receiver.Start(m =>
+                receiver.Start(async m =>
                 {
-                    m.Acknowledge();
+                    await m.AcknowledgeAsync();
                     waitHandle.Set();
                 });
 
@@ -101,9 +102,9 @@ namespace RockLib.Messaging.SQS.Tests
 
             using (var receiver = new SQSReceiver(mockSqs.Object, "foo", "http://url.com/foo", autoAcknowledge: false))
             {
-                receiver.Start(m =>
+                receiver.Start(async m =>
                 {
-                    m.Rollback();
+                    await m.RollbackAsync();
                     waitHandle.Set();
                 });
 
@@ -128,9 +129,9 @@ namespace RockLib.Messaging.SQS.Tests
 
             using (var receiver = new SQSReceiver(mockSqs.Object, "foo", "http://url.com/foo", autoAcknowledge: false))
             {
-                receiver.Start(m =>
+                receiver.Start(async m =>
                 {
-                    m.Reject();
+                    await m.RejectAsync();
                     waitHandle.Set();
                 });
 
@@ -155,7 +156,7 @@ namespace RockLib.Messaging.SQS.Tests
 
             using (var receiver = new SQSReceiver(mockSqs.Object, "foo", "http://url.com/foo", autoAcknowledge: true))
             {
-                receiver.Start(m =>
+                receiver.Start(async m =>
                 {
                     waitHandle.Set();
                 });
@@ -181,9 +182,9 @@ namespace RockLib.Messaging.SQS.Tests
 
             using (var receiver = new SQSReceiver(mockSqs.Object, "foo", "http://url.com/foo", autoAcknowledge: true))
             {
-                receiver.Start(m =>
+                receiver.Start(async m =>
                 {
-                    m.Rollback();
+                    await m.RollbackAsync();
                     waitHandle.Set();
                 });
 
@@ -286,3 +287,4 @@ namespace RockLib.Messaging.SQS.Tests
         }
     }
 }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously

--- a/RockLib.Messaging.SQS.Tests/SQSTests.cs
+++ b/RockLib.Messaging.SQS.Tests/SQSTests.cs
@@ -29,6 +29,64 @@ namespace RockLib.Messaging.SQS.Tests
         }
 
         [Fact]
+        public void SQSSenderSetsMessageGroupIdWhenSpecifiedInHeader()
+        {
+            var mockSqs = new Mock<IAmazonSQS>();
+
+            using (var sender = new SQSSender(mockSqs.Object, "foo", "http://url.com/foo"))
+                sender.Send(new SenderMessage("") { Headers = { { "SQS.MessageGroupId", "abc" } } });
+
+            mockSqs.Verify(m => m.SendMessageAsync(
+                It.Is<SendMessageRequest>(r =>
+                    !r.MessageAttributes.ContainsKey("SQS.MessageGroupId")
+                    && r.MessageGroupId == "abc"),
+                It.IsAny<CancellationToken>()));
+        }
+
+        [Fact]
+        public void SQSSenderSetsMessageGroupIdWhenSpecifiedInConstructor()
+        {
+            var mockSqs = new Mock<IAmazonSQS>();
+
+            using (var sender = new SQSSender(mockSqs.Object, "foo", "http://url.com/foo", "abc"))
+                sender.Send(new SenderMessage(""));
+
+            mockSqs.Verify(m => m.SendMessageAsync(
+                It.Is<SendMessageRequest>(r => r.MessageGroupId == "abc"),
+                It.IsAny<CancellationToken>()));
+        }
+
+        [Fact]
+        public void SQSSenderSetsMessageGroupIdToHeaderValueWhenSpecifiedInBothHeaderAndConstructor()
+        {
+            var mockSqs = new Mock<IAmazonSQS>();
+
+            using (var sender = new SQSSender(mockSqs.Object, "foo", "http://url.com/foo", "abc"))
+                sender.Send(new SenderMessage("") { Headers = { { "SQS.MessageGroupId", "xyz" } } });
+
+            mockSqs.Verify(m => m.SendMessageAsync(
+                It.Is<SendMessageRequest>(r =>
+                    !r.MessageAttributes.ContainsKey("SQS.MessageGroupId")
+                    && r.MessageGroupId == "xyz"),
+                It.IsAny<CancellationToken>()));
+        }
+
+        [Fact]
+        public void SQSSenderSetsMessageDeduplicationIdWhenSpecifiedInHeader()
+        {
+            var mockSqs = new Mock<IAmazonSQS>();
+
+            using (var sender = new SQSSender(mockSqs.Object, "foo", "http://url.com/foo"))
+                sender.Send(new SenderMessage("") { Headers = { { "SQS.MessageDeduplicationId", "abc" } } });
+
+            mockSqs.Verify(m => m.SendMessageAsync(
+                It.Is<SendMessageRequest>(r =>
+                    !r.MessageAttributes.ContainsKey("SQS.MessageDeduplicationId")
+                    && r.MessageDeduplicationId == "abc"),
+                It.IsAny<CancellationToken>()));
+        }
+
+        [Fact]
         public void SQSReceiverReceivesMessagesFromItsIAmazonSQS()
         {
             var mockSqs = new Mock<IAmazonSQS>();


### PR DESCRIPTION
Being able to set `MessageGroupId` is required for FIFO queues. This PR adds constructors to `SQSSender` containing a `messageGroupId` parameter. If this parameter has a value each outgoing SQS message will have its `MessageGroupId` set to the parameter. This PR also looks for a header named "SQS.MessageGroupId" in the outgoing message - if present, the SQS message will have its `MessageGroupId` set to the value of the header. Note that the message group ID from a header takes precedence over the message group ID set in the constructor.

This PR also looks for a header named "SQS.MessageDeduplicationId" in the outgoing message - if present, the SQS message will have its `MessageDeduplicationId` set to the value of the header. Note that there is _not_ a constructor parameter for this value because it doesn't make sense - values must be unique per message.