### PR TITLE
SQS Improvements

### DIFF
--- a/RockLib.Messaging.SQS/DependencyInjection/SQSReceiverOptions.cs
+++ b/RockLib.Messaging.SQS/DependencyInjection/SQSReceiverOptions.cs
@@ -1,4 +1,5 @@
 ﻿#if !NET451
+using Amazon.SQS;
 using RockLib.Messaging.SQS;
 using System;
 
@@ -14,6 +15,11 @@ namespace RockLib.Messaging.DependencyInjection
         private int _waitTimeSeconds = SQSReceiver.DefaultWaitTimeSeconds;
 
         /// <summary>
+        /// Gets or sets the object that communicates with SQS.
+        /// </summary>
+        public IAmazonSQS SqsClient { get; set; }
+
+        /// <summary>
         /// Gets or sets the url of the SQS queue.
         /// </summary>
         public string QueueUrl
@@ -23,7 +29,7 @@ namespace RockLib.Messaging.DependencyInjection
         }
 
         /// <summary>
-        /// Gets or sets the region of the SQS queue.
+        /// Gets or sets the region of the SQS client.
         /// </summary>
         public string Region { get; set; }
 

--- a/RockLib.Messaging.SQS/DependencyInjection/SQSSenderOptions.cs
+++ b/RockLib.Messaging.SQS/DependencyInjection/SQSSenderOptions.cs
@@ -1,4 +1,5 @@
 ﻿#if !NET451
+using Amazon.SQS;
 using RockLib.Messaging.SQS;
 using System;
 
@@ -21,7 +22,12 @@ namespace RockLib.Messaging.DependencyInjection
         }
 
         /// <summary>
-        /// Gets or sets the region of the SQS queue.
+        /// Gets or sets the object that communicates with SQS.
+        /// </summary>
+        public IAmazonSQS SqsClient { get; set; }
+
+        /// <summary>
+        /// Gets or sets the region of the SQS client.
         /// </summary>
         public string Region { get; set; }
 

--- a/RockLib.Messaging.SQS/SQSReceiver.cs
+++ b/RockLib.Messaging.SQS/SQSReceiver.cs
@@ -168,7 +168,8 @@ namespace RockLib.Messaging.SQS
                     MaxNumberOfMessages = MaxMessages,
                     QueueUrl = QueueUrl,
                     MessageAttributeNames = new List<string> { "*" },
-                    WaitTimeSeconds = WaitTimeSeconds
+                    WaitTimeSeconds = WaitTimeSeconds,
+                    AttributeNames = new List<string> { "All" }
                 };
 
                 ReceiveMessageResponse response = null;

--- a/RockLib.Messaging.SQS/SQSReceiverMessage.cs
+++ b/RockLib.Messaging.SQS/SQSReceiverMessage.cs
@@ -44,12 +44,18 @@ namespace RockLib.Messaging.SQS
             if (TryGetSNSMessage(Message.Body, _unpackSns, out var snsMessage))
             {
                 headers["TopicARN"] = snsMessage.TopicARN;
+
                 foreach (var attribute in snsMessage.MessageAttributes)
                     headers[attribute.Key] = attribute.Value.Value;
             }
             else
+            {
+                foreach (var attribute in Message.Attributes)
+                    headers[$"SQS.{attribute.Key}"] = attribute.Value;
+
                 foreach (var attribute in Message.MessageAttributes)
-                    headers.Add(attribute.Key, attribute.Value.StringValue);
+                    headers[attribute.Key] = attribute.Value.StringValue;
+            }
         }
 
         private static string GetRawPayload(string messageBody, bool unpackSNS)


### PR DESCRIPTION
- Maps the values of the `Amazon.SQS.Model.Message.Attributes` dictionary to the RockLib message's headers.
- Adds `SqsClient` property to options classes, making it possible to specify the SQS client from the DI extension methods.