### PR TITLE
Changes based on feedback from demo

### DIFF
--- a/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -1,0 +1,409 @@
+﻿using FluentAssertions;
+using Newtonsoft.Json;
+using RockLib.Dynamic;
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Xml.Serialization;
+using Xunit;
+
+namespace RockLib.Messaging.CloudEvents.Tests
+{
+    public class CloudEventExtensionsTests
+    {
+        private static readonly ConditionalWeakTable<CloudEvent, object> _dataObjects = typeof(CloudEventExtensions).Unlock()._dataObjects;
+
+        [Fact(DisplayName = "SetData method 1 sets the data field and clears the data object")]
+        public void SetDataMethod1HappyPath1()
+        {
+            var cloudEvent = new CloudEvent();
+
+            // In order to verify that the method cleared the data object, there needs to be one first.
+            _dataObjects.Add(cloudEvent, new object());
+
+            var stringData = "Hello, world!";
+
+            cloudEvent.SetData(stringData);
+
+            string data = cloudEvent.Unlock()._data;
+
+            data.Should().Be(stringData);
+            _dataObjects.TryGetValue(cloudEvent, out _).Should().BeFalse();
+        }
+
+        [Fact(DisplayName = "SetData method 1 does nothing if new value isn't different")]
+        public void SetDataMethod1HappyPath2()
+        {
+            var cloudEvent = new CloudEvent();
+
+            // In order to verify that _data has not changed, capture its initial value.
+            cloudEvent.Unlock()._data = "Hello, world!";
+
+            // In order to verify that the method did not clear the data object, there needs to be one first.
+            _dataObjects.Add(cloudEvent, new object());
+
+            cloudEvent.SetData($"Hello, {"WORLD".ToLowerInvariant()}!");
+
+            string data = cloudEvent.Unlock()._data;
+
+            data.Should().Be("Hello, world!");
+            _dataObjects.TryGetValue(cloudEvent, out _).Should().BeTrue();
+        }
+
+        [Fact(DisplayName = "SetData method 1 throws if cloudEvent is null")]
+        public void SetDataMethod1SadPath()
+        {
+            CloudEvent cloudEvent = null;
+
+            Action act = () => cloudEvent.SetData("Hello, world!");
+
+            act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*cloudEvent*");
+        }
+
+        [Fact(DisplayName = "SetData method 2 sets the data field and clears the data object")]
+        public void SetDataMethod2HappyPath1()
+        {
+            var cloudEvent = new CloudEvent();
+
+            // In order to verify that the method cleared the data object, there needs to be one first.
+            _dataObjects.Add(cloudEvent, new object());
+
+            var binaryData = new byte[] { 1, 2, 3, 4 };
+
+            cloudEvent.SetData(binaryData);
+
+            cloudEvent.BinaryData.Should().BeSameAs(binaryData);
+            _dataObjects.TryGetValue(cloudEvent, out _).Should().BeFalse();
+        }
+
+        [Fact(DisplayName = "SetData method 2 does nothing if new value is same instance")]
+        public void SetDataMethod2HappyPath2()
+        {
+            var cloudEvent = new CloudEvent();
+
+            var binaryData = new byte[] { 1, 2, 3, 4 };
+
+            cloudEvent.Unlock()._data = binaryData;
+
+            // In order to verify that the method did not clear the data object, there needs to be one first.
+            _dataObjects.Add(cloudEvent, new object());
+
+            cloudEvent.SetData(binaryData);
+
+            byte[] data = cloudEvent.Unlock()._data;
+
+            data.Should().BeSameAs(binaryData);
+            _dataObjects.TryGetValue(cloudEvent, out _).Should().BeTrue();
+        }
+
+        [Fact(DisplayName = "SetData method 2 does nothing if new value is equivalent")]
+        public void SetDataMethod2HappyPath3()
+        {
+            var cloudEvent = new CloudEvent();
+
+            var binaryData = new byte[] { 1, 2, 3, 4 };
+
+            // In order to verify that _data has not changed, capture its initial value.
+            cloudEvent.Unlock()._data = binaryData;
+
+            // In order to verify that the method did not clear the data object, there needs to be one first.
+            _dataObjects.Add(cloudEvent, new object());
+
+            cloudEvent.SetData(new byte[] { 1, 2, 3, 4 });
+
+            byte[] data = cloudEvent.Unlock()._data;
+
+            data.Should().BeSameAs(binaryData);
+            _dataObjects.TryGetValue(cloudEvent, out _).Should().BeTrue();
+        }
+
+        [Fact(DisplayName = "SetData method 2 throws if cloudEvent is null")]
+        public void SetDataMethod2SadPath()
+        {
+            CloudEvent cloudEvent = null;
+
+            Action act = () => cloudEvent.SetData(new byte[] { 1, 2, 3, 4 });
+
+            act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*cloudEvent*");
+        }
+
+        [Fact(DisplayName = "SetData method 3 sets the data field with JSON and sets the data object")]
+        public void SetDataMethod3HappyPath1()
+        {
+            var cloudEvent = new CloudEvent();
+            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+
+            cloudEvent.SetData(client);
+
+            string data = cloudEvent.Unlock()._data;
+
+            data.Should().Be(JsonConvert.SerializeObject(client));
+            _dataObjects.TryGetValue(cloudEvent, out var value).Should().BeTrue();
+            value.Should().BeSameAs(client);
+        }
+
+        [Fact(DisplayName = "SetData method 3 sets the data field with XML and sets the data object")]
+        public void SetDataMethod3HappyPath2()
+        {
+            var cloudEvent = new CloudEvent();
+            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+
+            cloudEvent.SetData(client, DataSerialization.Xml);
+
+            string data = cloudEvent.Unlock()._data;
+
+            data.Should().Be(XmlSerialize(client));
+            _dataObjects.TryGetValue(cloudEvent, out var value).Should().BeTrue();
+            value.Should().BeSameAs(client);
+        }
+
+        [Fact(DisplayName = "SetData method 3 clears the data field and the data object if data is null")]
+        public void SetDataMethod3HappyPath3()
+        {
+            var cloudEvent = new CloudEvent();
+
+            // In order to verify that _data has been cleared, capture its initial value.
+            cloudEvent.Unlock()._data = "Hello, world!";
+
+            // In order to verify that the method cleared the data object, there needs to be one first.
+            _dataObjects.Add(cloudEvent, new object());
+
+            Client client = null;
+
+            cloudEvent.SetData(client);
+
+            object data = cloudEvent.Unlock()._data;
+
+            data.Should().BeNull();
+            _dataObjects.TryGetValue(cloudEvent, out _).Should().BeFalse();
+        }
+
+        [Fact(DisplayName = "SetData method 3 throws if cloudEvent is null")]
+        public void SetDataMethod3SadPath1()
+        {
+            CloudEvent cloudEvent = null;
+            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+
+            Action act = () => cloudEvent.SetData(client);
+
+            act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*cloudEvent*");
+        }
+
+        [Fact(DisplayName = "SetData method 3 throws if serialization is not defined")]
+        public void SetDataMethod3SadPath2()
+        {
+            var cloudEvent = new CloudEvent();
+            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+            var serialization = (DataSerialization)(-123);
+
+            Action act = () => cloudEvent.SetData(client, serialization);
+
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithMessage("*serialization*");
+        }
+
+        [Fact(DisplayName = "GetData method JSON deserializes StringData")]
+        public void GetDataMethodHappyPath1()
+        {
+            var cloudEvent = new CloudEvent();
+            var clientData = JsonConvert.SerializeObject(new Client { FirstName = "Brian", LastName = "Friesen" });
+
+            cloudEvent.Unlock()._data = clientData;
+
+            var client = cloudEvent.GetData<Client>();
+
+            client.FirstName.Should().Be("Brian");
+            client.LastName.Should().Be("Friesen");
+        }
+
+        [Fact(DisplayName = "GetData method XML deserializes StringData")]
+        public void GetDataMethodHappyPath2()
+        {
+            var cloudEvent = new CloudEvent();
+            var clientData = XmlSerialize(new Client { FirstName = "Brian", LastName = "Friesen" });
+
+            cloudEvent.Unlock()._data = clientData;
+
+            var client = cloudEvent.GetData<Client>(DataSerialization.Xml);
+
+            client.FirstName.Should().Be("Brian");
+            client.LastName.Should().Be("Friesen");
+        }
+
+        [Fact(DisplayName = "GetData method returns data object if it already exists")]
+        public void GetDataMethodHappyPath3()
+        {
+            var cloudEvent = new CloudEvent();
+            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+
+            _dataObjects.Add(cloudEvent, client);
+
+            cloudEvent.GetData<Client>().Should().BeSameAs(client);
+        }
+
+        [Fact(DisplayName = "GetData method throws if cloudEvent is null")]
+        public void GetDataMethodSadPath1()
+        {
+            CloudEvent cloudEvent = null;
+
+            Action act = () => cloudEvent.GetData<Client>();
+
+            act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*cloudEvent*");
+        }
+
+        [Fact(DisplayName = "GetData method throws if serialization is not defined")]
+        public void GetDataMethodSadPath2()
+        {
+            var cloudEvent = new CloudEvent();
+            var serialization = (DataSerialization)(-123);
+
+            Action act = () => cloudEvent.GetData<Client>(serialization);
+
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithMessage("*serialization*");
+        }
+
+        [Fact(DisplayName = "GetData method throws if StringData is invalid JSON")]
+        public void GetDataMethodSadPath3()
+        {
+            var cloudEvent = new CloudEvent();
+
+            cloudEvent.Unlock()._data = "Not valid JSON";
+
+            Action act = () => cloudEvent.GetData<Client>();
+
+            act.Should().Throw<JsonException>();
+        }
+
+        [Fact(DisplayName = "GetData method throws if StringData is invalid XML")]
+        public void GetDataMethodSadPath4()
+        {
+            var cloudEvent = new CloudEvent();
+
+            cloudEvent.Unlock()._data = "Not valid JSON";
+
+            Action act = () => cloudEvent.GetData<Client>(DataSerialization.Xml);
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact(DisplayName = "GetData method throws if data object already exists and cannot be cast to T")]
+        public void GetDataMethodSadPath5()
+        {
+            var cloudEvent = new CloudEvent();
+
+            _dataObjects.Add(cloudEvent, new NotAClient());
+
+            Action act = () => cloudEvent.GetData<Client>();
+
+            act.Should().ThrowExactly<InvalidCastException>();
+        }
+
+        [Fact(DisplayName = "TryGetData method JSON deserializes StringData")]
+        public void TryGetDataMethodHappyPath1()
+        {
+            var cloudEvent = new CloudEvent();
+            var clientData = JsonConvert.SerializeObject(new Client { FirstName = "Brian", LastName = "Friesen" });
+
+            cloudEvent.Unlock()._data = clientData;
+
+            cloudEvent.TryGetData(out Client client).Should().BeTrue();
+
+            client.FirstName.Should().Be("Brian");
+            client.LastName.Should().Be("Friesen");
+        }
+
+        [Fact(DisplayName = "TryGetData method XML deserializes StringData")]
+        public void TryGetDataMethodHappyPath2()
+        {
+            var cloudEvent = new CloudEvent();
+            var clientData = XmlSerialize(new Client { FirstName = "Brian", LastName = "Friesen" });
+
+            cloudEvent.Unlock()._data = clientData;
+
+            cloudEvent.TryGetData(out Client client, DataSerialization.Xml).Should().BeTrue();
+
+            client.FirstName.Should().Be("Brian");
+            client.LastName.Should().Be("Friesen");
+        }
+
+        [Fact(DisplayName = "TryGetData method returns data object if it already exists")]
+        public void TryGetDataMethodHappyPath3()
+        {
+            var cloudEvent = new CloudEvent();
+            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+
+            _dataObjects.Add(cloudEvent, client);
+
+            cloudEvent.TryGetData(out Client actualClient).Should().BeTrue();
+            actualClient.Should().BeSameAs(client);
+        }
+
+        [Fact(DisplayName = "TryGetData method throws if cloudEvent is null")]
+        public void TryGetDataMethodSadPath1()
+        {
+            CloudEvent cloudEvent = null;
+
+            Action act = () => cloudEvent.TryGetData(out Client client);
+
+            act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*cloudEvent*");
+        }
+
+        [Fact(DisplayName = "TryGetData method throws if serialization is not defined")]
+        public void TryGetDataMethodSadPath2()
+        {
+            var cloudEvent = new CloudEvent();
+            var serialization = (DataSerialization)(-123);
+
+            Action act = () => cloudEvent.TryGetData(out Client client, serialization);
+
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithMessage("*serialization*");
+        }
+
+        [Fact(DisplayName = "TryGetData method returns false if StringData is invalid JSON")]
+        public void TryGetDataMethodSadPath3()
+        {
+            var cloudEvent = new CloudEvent();
+
+            cloudEvent.Unlock()._data = "Not valid JSON";
+
+            cloudEvent.TryGetData(out Client _).Should().BeFalse();
+        }
+
+        [Fact(DisplayName = "TryGetData method returns false if StringData is invalid XML")]
+        public void TryGetDataMethodSadPath4()
+        {
+            var cloudEvent = new CloudEvent();
+
+            cloudEvent.Unlock()._data = "Not valid JSON";
+
+            cloudEvent.TryGetData(out Client _, DataSerialization.Xml).Should().BeFalse();
+        }
+
+        [Fact(DisplayName = "TryGetData method returns false if data object already exists and cannot be cast to T")]
+        public void TryGetDataMethodSadPath5()
+        {
+            var cloudEvent = new CloudEvent();
+
+            _dataObjects.Add(cloudEvent, new NotAClient());
+
+            cloudEvent.TryGetData(out Client _).Should().BeFalse();
+        }
+
+        private static string XmlSerialize(Client client)
+        {
+            var sb = new StringBuilder();
+            var serializer = new XmlSerializer(typeof(Client));
+            using (var writer = new StringWriter(sb))
+                serializer.Serialize(writer, client);
+            return sb.ToString();
+        }
+
+        public class Client
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+        }
+
+        public class NotAClient { }
+    }
+}

--- a/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -73,7 +73,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent(receiverMessage);
 
             cloudEvent.BinaryData.Should().BeSameAs(binaryData);
-            cloudEvent.StringData.Should().Be(Convert.ToBase64String(binaryData));
+            cloudEvent.StringData.Should().BeNull();
         }
 
         [Fact(DisplayName = "Constructor 3 creates cloud event with string data")]
@@ -86,7 +86,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent(receiverMessage);
 
             cloudEvent.StringData.Should().BeSameAs(stringData);
-            cloudEvent.BinaryData.Should().BeEquivalentTo(Encoding.UTF8.GetBytes(stringData));
+            cloudEvent.BinaryData.Should().BeNull();
         }
 
         [Fact(DisplayName = "Constructor 3 maps cloud event attributes from receiver message headers")]
@@ -298,7 +298,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.StringData.Should().Be(stringData);
         }
 
-        [Fact(DisplayName = "StringData returns the binary data passed to SetData, base-64 encoded")]
+        [Fact(DisplayName = "StringData returns null if data is binary")]
         public void StringDataPropertyHappyPath2()
         {
             var cloudEvent = new CloudEvent();
@@ -307,7 +307,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.SetData(binaryData);
 
-            cloudEvent.StringData.Should().Be(Convert.ToBase64String(binaryData));
+            cloudEvent.StringData.Should().BeNull();
         }
 
         [Fact(DisplayName = "StringData returns null if uninitialized")]
@@ -330,7 +330,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.BinaryData.Should().BeEquivalentTo(binaryData);
         }
 
-        [Fact(DisplayName = "BinaryData returns the string data passed to SetData, utf-8 encoded")]
+        [Fact(DisplayName = "BinaryData returns null if the data is string")]
         public void BinaryDataPropertyHappyPath2()
         {
             var cloudEvent = new CloudEvent();
@@ -339,7 +339,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.SetData(stringData);
 
-            cloudEvent.BinaryData.Should().BeEquivalentTo(Encoding.UTF8.GetBytes(stringData));
+            cloudEvent.BinaryData.Should().BeNull();
         }
 
         [Fact(DisplayName = "BinaryData returns null if uninitialized")]

--- a/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -286,8 +286,8 @@ namespace RockLib.Messaging.CloudEvents.Tests
             time.Should().BeOnOrBefore(after);
         }
 
-        [Fact(DisplayName = "StringData property setter and getter work as expected")]
-        public void DataPropertyHappyPath1()
+        [Fact(DisplayName = "StringData returns the string data passed to SetData")]
+        public void StringDataPropertyHappyPath1()
         {
             var cloudEvent = new CloudEvent();
 
@@ -296,11 +296,30 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.SetData(stringData);
 
             cloudEvent.StringData.Should().Be(stringData);
-            cloudEvent.BinaryData.Should().BeEquivalentTo(Encoding.UTF8.GetBytes(stringData));
         }
 
-        [Fact(DisplayName = "BinaryData property setter and getter work as expected")]
-        public void DataPropertyHappyPath2()
+        [Fact(DisplayName = "StringData returns the binary data passed to SetData, base-64 encoded")]
+        public void StringDataPropertyHappyPath2()
+        {
+            var cloudEvent = new CloudEvent();
+
+            var binaryData = new byte[] { 1, 2, 3, 4 };
+
+            cloudEvent.SetData(binaryData);
+
+            cloudEvent.StringData.Should().Be(Convert.ToBase64String(binaryData));
+        }
+
+        [Fact(DisplayName = "StringData returns null if uninitialized")]
+        public void StringDataPropertyHappyPath3()
+        {
+            var cloudEvent = new CloudEvent();
+
+            cloudEvent.StringData.Should().BeNull();
+        }
+
+        [Fact(DisplayName = "BinaryData returns the binary data passed to SetData")]
+        public void BinaryDataPropertyHappyPath1()
         {
             var cloudEvent = new CloudEvent();
 
@@ -309,7 +328,26 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.SetData(binaryData);
 
             cloudEvent.BinaryData.Should().BeEquivalentTo(binaryData);
-            cloudEvent.StringData.Should().Be(Convert.ToBase64String(binaryData));
+        }
+
+        [Fact(DisplayName = "BinaryData returns the string data passed to SetData, utf-8 encoded")]
+        public void BinaryDataPropertyHappyPath2()
+        {
+            var cloudEvent = new CloudEvent();
+
+            var stringData = "Hello, world!";
+
+            cloudEvent.SetData(stringData);
+
+            cloudEvent.BinaryData.Should().BeEquivalentTo(Encoding.UTF8.GetBytes(stringData));
+        }
+
+        [Fact(DisplayName = "BinaryData returns null if uninitialized")]
+        public void BinaryDataPropertyHappyPath3()
+        {
+            var cloudEvent = new CloudEvent();
+
+            cloudEvent.BinaryData.Should().BeNull();
         }
 
         #endregion
@@ -326,9 +364,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
                 Id = "MyId",
                 Source = new Uri("http://mysource/"),
                 Type = "MyType"
-            };
-
-            cloudEvent.SetData(stringData);
+            }.SetData(stringData);
 
             var senderMessage = cloudEvent.ToSenderMessage();
 
@@ -345,9 +381,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
                 Id = "MyId",
                 Source = new Uri("http://mysource/"),
                 Type = "MyType"
-            };
-
-            cloudEvent.SetData(binaryData);
+            }.SetData(binaryData);
 
             var senderMessage = cloudEvent.ToSenderMessage();
 

--- a/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -3,7 +3,6 @@ using Moq;
 using RockLib.Messaging.Testing;
 using System;
 using System.Net.Mime;
-using System.Text;
 using Xunit;
 
 namespace RockLib.Messaging.CloudEvents.Tests

--- a/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -293,7 +293,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var stringData = "Hello, world!";
 
-            cloudEvent.StringData = stringData;
+            cloudEvent.SetData(stringData);
 
             cloudEvent.StringData.Should().Be(stringData);
             cloudEvent.BinaryData.Should().BeEquivalentTo(Encoding.UTF8.GetBytes(stringData));
@@ -306,7 +306,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var binaryData = new byte[] { 1, 2, 3, 4 };
 
-            cloudEvent.BinaryData = binaryData;
+            cloudEvent.SetData(binaryData);
 
             cloudEvent.BinaryData.Should().BeEquivalentTo(binaryData);
             cloudEvent.StringData.Should().Be(Convert.ToBase64String(binaryData));
@@ -323,11 +323,12 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var cloudEvent = new CloudEvent
             {
-                StringData = stringData,
                 Id = "MyId",
                 Source = new Uri("http://mysource/"),
                 Type = "MyType"
             };
+
+            cloudEvent.SetData(stringData);
 
             var senderMessage = cloudEvent.ToSenderMessage();
 
@@ -341,11 +342,12 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var cloudEvent = new CloudEvent
             {
-                BinaryData = binaryData,
                 Id = "MyId",
                 Source = new Uri("http://mysource/"),
                 Type = "MyType"
             };
+
+            cloudEvent.SetData(binaryData);
 
             var senderMessage = cloudEvent.ToSenderMessage();
 
@@ -645,7 +647,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var mockCloudEvent = new Mock<CloudEvent>();
             mockCloudEvent.Setup(m => m.ToSenderMessage()).CallBase();
             mockCloudEvent.Setup(m => m.Validate()).CallBase();
-            mockCloudEvent.Object.StringData = "Hello, world!";
+            mockCloudEvent.Object.SetData("Hello, world!");
             mockCloudEvent.Object.Id = "MyId";
             mockCloudEvent.Object.Source = new Uri("http://mysource/");
             mockCloudEvent.Object.Type = "test";

--- a/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -34,10 +34,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
             {
                 Id = "MyId",
                 Time = new DateTime(2020, 7, 9, 22, 21, 37, DateTimeKind.Local),
-                Source = new Uri("http://mysource/"),
+                Source = "http://mysource/",
                 Type = "MyType",
-                DataContentType = new ContentType("application/json; charset=utf-8"),
-                DataSchema = new Uri("http://mydataschema/"),
+                DataContentType = "application/json; charset=utf-8",
+                DataSchema = "http://mydataschema/",
                 Subject = "MySubject"
             };
 
@@ -96,9 +96,9 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var receiverMessage = new FakeReceiverMessage("Hello, world!");
 
-            var source = new Uri("http://MySource");
-            var dataContentType = new ContentType("application/mycontenttype");
-            var dataSchema = new Uri("http://MySource");
+            var source = "http://MySource";
+            var dataContentType = "application/mycontenttype";
+            var dataSchema = "http://MySource";
             var time = DateTime.UtcNow;
 
             receiverMessage.Headers.Add(CloudEvent.SpecVersionAttribute, "1.0");
@@ -362,7 +362,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent
             {
                 Id = "MyId",
-                Source = new Uri("http://mysource/"),
+                Source = "http://mysource/",
                 Type = "MyType"
             }.SetData(stringData);
 
@@ -379,7 +379,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent
             {
                 Id = "MyId",
-                Source = new Uri("http://mysource/"),
+                Source = "http://mysource/",
                 Type = "MyType"
             }.SetData(binaryData);
 
@@ -396,7 +396,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent
             {
                 Id = "MyId",
-                Source = new Uri("http://mysource/"),
+                Source = "http://mysource/",
                 Type = "MyType"
             };
 
@@ -410,10 +410,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // All attributes provided
 
-            var dataContentType = new ContentType("application/xml");
-            var dataSchema = new Uri("http://dataschema");
+            var dataContentType = "application/xml";
+            var dataSchema = "http://dataschema";
             var id = "MyId";
-            Uri source = new Uri("http://source");
+            var source = "http://source";
             var subject = "MySubject";
             var time = DateTime.UtcNow;
             var type = "MyType";
@@ -449,7 +449,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent
             {
                 Id = "MyId",
-                Source = new Uri("http://MySource"),
+                Source = "http://MySource",
                 Type = "MyType"
             };
 
@@ -468,7 +468,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var cloudEvent = new CloudEvent();
             cloudEvent.Id = "MyId";
-            cloudEvent.Source = new Uri("http://mysource/");
+            cloudEvent.Source = "http://mysource/";
             cloudEvent.Type = "MyType";
             cloudEvent.AdditionalAttributes.Add("foo", "abc");
             cloudEvent.AdditionalAttributes.Add("bar", 123);
@@ -493,7 +493,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent
             {
                 Id = id,
-                Source = new Uri("http://mysource/"),
+                Source = "http://mysource/",
                 Type = "MyType",
                 AdditionalAttributes = { { "foo", "abc" } },
                 ProtocolBinding = mockProtocolBinding.Object
@@ -683,7 +683,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             mockCloudEvent.Setup(m => m.Validate()).CallBase();
             mockCloudEvent.Object.SetData("Hello, world!");
             mockCloudEvent.Object.Id = "MyId";
-            mockCloudEvent.Object.Source = new Uri("http://mysource/");
+            mockCloudEvent.Object.Source = "http://mysource/";
             mockCloudEvent.Object.Type = "test";
             mockCloudEvent.Object.AdditionalAttributes.Add("foo", "abc");
 

--- a/RockLib.Messaging.CloudEvents.Tests/CorrelatedEventTests.cs
+++ b/RockLib.Messaging.CloudEvents.Tests/CorrelatedEventTests.cs
@@ -34,10 +34,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
                 CorrelationId = "MyCorrelationId",
                 Id = "MyId",
                 Time = new DateTime(2020, 7, 9, 22, 21, 37, DateTimeKind.Local),
-                Source = new Uri("http://mysource/"),
+                Source = "http://mysource/",
                 Type = "MyType",
-                DataContentType = new ContentType("application/json") { CharSet = "utf-8" },
-                DataSchema = new Uri("http://mydataschema/"),
+                DataContentType = "application/json; charset=utf-8",
+                DataSchema = "http://mydataschema/",
                 Subject = "MySubject"
             };
 
@@ -72,9 +72,9 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var receiverMessage = new FakeReceiverMessage("Hello, world!");
 
-            var source = new Uri("http://MySource");
-            var dataContentType = new ContentType("application/mycontenttype");
-            var dataSchema = new Uri("http://MySource");
+            var source = "http://MySource";
+            var dataContentType = "application/mycontenttype";
+            var dataSchema = "http://MySource";
             var time = DateTime.UtcNow;
 
             receiverMessage.Headers.Add(CorrelatedEvent.CorrelationIdAttribute, "MyCorrelationId");
@@ -125,9 +125,9 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var receiverMessage = new FakeReceiverMessage("Hello, world!");
 
-            var source = new Uri("http://MySource");
-            var dataContentType = new ContentType("application/mycontenttype");
-            var dataSchema = new Uri("http://MySource");
+            var source = "http://MySource";
+            var dataContentType = "application/mycontenttype";
+            var dataSchema = "http://MySource";
             var time = DateTime.UtcNow;
 
             receiverMessage.Headers.Add("test-" + CorrelatedEvent.CorrelationIdAttribute, "MyCorrelationId");
@@ -192,10 +192,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
             // All attributes provided
 
             var correlationId = "MyCorrelationId";
-            var dataContentType = new ContentType("application/xml");
-            var dataSchema = new Uri("http://dataschema");
+            var dataContentType = "application/xml";
+            var dataSchema = "http://dataschema";
             var id = "MyId";
-            Uri source = new Uri("http://source");
+            var source = "http://source";
             var subject = "MySubject";
             var time = DateTime.UtcNow;
             var type = "MyType";
@@ -234,7 +234,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CorrelatedEvent
             {
                 Id = "MyId",
-                Source = new Uri("http://MySource"),
+                Source = "http://MySource",
                 Type = "MyType"
             };
 
@@ -254,10 +254,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
             // Non-default protocol binding
 
             var correlationId = "MyCorrelationId";
-            var dataContentType = new ContentType("application/xml");
-            var dataSchema = new Uri("http://dataschema");
+            var dataContentType = "application/xml";
+            var dataSchema = "http://dataschema";
             var id = "MyId";
-            Uri source = new Uri("http://source");
+            var source = "http://source";
             var subject = "MySubject";
             var time = DateTime.UtcNow;
             var type = "MyType";

--- a/RockLib.Messaging.CloudEvents.Tests/RockLib.Messaging.CloudEvents.Tests.csproj
+++ b/RockLib.Messaging.CloudEvents.Tests/RockLib.Messaging.CloudEvents.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="RockLib.UniversalMemberAccessor" Version="1.0.4" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/RockLib.Messaging.CloudEvents.Tests/SequentialEventTests.cs
+++ b/RockLib.Messaging.CloudEvents.Tests/SequentialEventTests.cs
@@ -36,10 +36,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
                 SequenceType = SequenceTypes.Integer,
                 Id = "MyId",
                 Time = new DateTime(2020, 7, 9, 22, 21, 37, DateTimeKind.Local),
-                Source = new Uri("http://mysource/"),
+                Source = "http://mysource/",
                 Type = "MyType",
-                DataContentType = new ContentType("application/json") { CharSet = "utf-8" },
-                DataSchema = new Uri("http://mydataschema/"),
+                DataContentType = "application/json; charset=utf-8",
+                DataSchema = "http://mydataschema/",
                 Subject = "MySubject"
             };
 
@@ -75,9 +75,9 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var receiverMessage = new FakeReceiverMessage("Hello, world!");
 
-            var source = new Uri("http://MySource");
-            var dataContentType = new ContentType("application/mycontenttype");
-            var dataSchema = new Uri("http://MySource");
+            var source = "http://MySource";
+            var dataContentType = "application/mycontenttype";
+            var dataSchema = "http://MySource";
             var time = DateTime.UtcNow;
 
             receiverMessage.Headers.Add(SequentialEvent.SequenceAttribute, "1");
@@ -133,9 +133,9 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var receiverMessage = new FakeReceiverMessage("Hello, world!");
 
-            var source = new Uri("http://MySource");
-            var dataContentType = new ContentType("application/mycontenttype");
-            var dataSchema = new Uri("http://MySource");
+            var source = "http://MySource";
+            var dataContentType = "application/mycontenttype";
+            var dataSchema = "http://MySource";
             var time = DateTime.UtcNow;
 
             receiverMessage.Headers.Add("test-" + SequentialEvent.SequenceAttribute, "1");
@@ -174,10 +174,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var sequential = "1";
             var sequentialType = SequenceTypes.Integer;
-            var dataContentType = new ContentType("application/xml");
-            var dataSchema = new Uri("http://dataschema");
+            var dataContentType = "application/xml";
+            var dataSchema = "http://dataschema";
             var id = "MyId";
-            Uri source = new Uri("http://source");
+            var source = "http://source";
             var subject = "MySubject";
             var time = DateTime.UtcNow;
             var type = "MyType";
@@ -219,7 +219,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             {
                 Sequence = "MySequence",
                 Id = "MyId",
-                Source = new Uri("http://MySource"),
+                Source = "http://MySource",
                 Type = "MyType"
             };
 
@@ -240,10 +240,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var sequence = "1";
             var sequenceType = SequenceTypes.Integer;
-            var dataContentType = new ContentType("application/xml");
-            var dataSchema = new Uri("http://dataschema");
+            var dataContentType = "application/xml";
+            var dataSchema = "http://dataschema";
             var id = "MyId";
-            Uri source = new Uri("http://source");
+            var source = "http://source";
             var subject = "MySubject";
             var time = DateTime.UtcNow;
             var type = "MyType";

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using static RockLib.Messaging.HttpUtils;
 
 namespace RockLib.Messaging.CloudEvents
@@ -98,64 +97,7 @@ namespace RockLib.Messaging.CloudEvents
             if (receiverMessage is null)
                 throw new ArgumentNullException(nameof(receiverMessage));
 
-            ProtocolBinding = protocolBinding ?? DefaultProtocolBinding;
-
-            _data = receiverMessage.IsBinary()
-                ? (object)receiverMessage.BinaryPayload
-                : receiverMessage.StringPayload;
-
-            foreach (var header in receiverMessage.Headers)
-                AdditionalAttributes.Add(header);
-
-            if (receiverMessage.Headers.TryGetValue(SpecVersionHeader, out string specVersion))
-            {
-                if (specVersion != _specVersion1_0)
-                    throw new CloudEventValidationException(
-                        $"Invalid value found in '{SpecVersionHeader}' header. Expected '{_specVersion1_0}', but was '{specVersion}'.");
-                AdditionalAttributes.Remove(SpecVersionHeader);
-            }
-
-            if (receiverMessage.Headers.TryGetValue(IdHeader, out string id))
-            {
-                Id = id;
-                AdditionalAttributes.Remove(IdHeader);
-            }
-
-            if (receiverMessage.Headers.TryGetValue(SourceHeader, out string source))
-            {
-                Source = source;
-                AdditionalAttributes.Remove(SourceHeader);
-            }
-
-            if (receiverMessage.Headers.TryGetValue(TypeHeader, out string type))
-            {
-                Type = type;
-                AdditionalAttributes.Remove(TypeHeader);
-            }
-
-            if (receiverMessage.Headers.TryGetValue(DataContentTypeHeader, out string dataContentType))
-            {
-                DataContentType = dataContentType;
-                AdditionalAttributes.Remove(DataContentTypeHeader);
-            }
-
-            if (receiverMessage.Headers.TryGetValue(DataSchemaHeader, out string dataSchema))
-            {
-                DataSchema = dataSchema;
-                AdditionalAttributes.Remove(DataSchemaHeader);
-            }
-
-            if (receiverMessage.Headers.TryGetValue(SubjectHeader, out string subject))
-            {
-                Subject = subject;
-                AdditionalAttributes.Remove(SubjectHeader);
-            }
-
-            if (receiverMessage.Headers.TryGetValue(TimeHeader, out DateTime time))
-            {
-                Time = time;
-                AdditionalAttributes.Remove(TimeHeader);
-            }
+            FromReceiverMessage(receiverMessage, protocolBinding);
         }
 
         /// <summary>
@@ -344,6 +286,68 @@ namespace RockLib.Messaging.CloudEvents
                 senderMessage.Headers[attribute.Key] = attribute.Value;
 
             return senderMessage;
+        }
+
+        private void FromReceiverMessage(IReceiverMessage receiverMessage, IProtocolBinding protocolBinding)
+        {
+            ProtocolBinding = protocolBinding ?? DefaultProtocolBinding;
+
+            _data = receiverMessage.IsBinary()
+                ? (object)receiverMessage.BinaryPayload
+                : receiverMessage.StringPayload;
+
+            foreach (var header in receiverMessage.Headers)
+                AdditionalAttributes.Add(header);
+
+            if (receiverMessage.Headers.TryGetValue(SpecVersionHeader, out string specVersion))
+            {
+                if (specVersion != _specVersion1_0)
+                    throw new CloudEventValidationException(
+                        $"Invalid value found in '{SpecVersionHeader}' header. Expected '{_specVersion1_0}', but was '{specVersion}'.");
+                AdditionalAttributes.Remove(SpecVersionHeader);
+            }
+
+            if (receiverMessage.Headers.TryGetValue(IdHeader, out string id))
+            {
+                Id = id;
+                AdditionalAttributes.Remove(IdHeader);
+            }
+
+            if (receiverMessage.Headers.TryGetValue(SourceHeader, out string source))
+            {
+                Source = source;
+                AdditionalAttributes.Remove(SourceHeader);
+            }
+
+            if (receiverMessage.Headers.TryGetValue(TypeHeader, out string type))
+            {
+                Type = type;
+                AdditionalAttributes.Remove(TypeHeader);
+            }
+
+            if (receiverMessage.Headers.TryGetValue(DataContentTypeHeader, out string dataContentType))
+            {
+                DataContentType = dataContentType;
+                AdditionalAttributes.Remove(DataContentTypeHeader);
+            }
+
+            if (receiverMessage.Headers.TryGetValue(DataSchemaHeader, out string dataSchema))
+            {
+                DataSchema = dataSchema;
+                AdditionalAttributes.Remove(DataSchemaHeader);
+            }
+
+            if (receiverMessage.Headers.TryGetValue(SubjectHeader, out string subject))
+            {
+                Subject = subject;
+                AdditionalAttributes.Remove(SubjectHeader);
+            }
+
+            if (receiverMessage.Headers.TryGetValue(TimeHeader, out DateTime time))
+            {
+                Time = time;
+                AdditionalAttributes.Remove(TimeHeader);
+            }
         }
 
         /// <summary>

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mime;
@@ -264,11 +263,6 @@ namespace RockLib.Messaging.CloudEvents
         /// Domain-specific information about the occurrence (i.e. the payload) as a string. This
         /// might include information about the occurrence, details about the data that was
         /// changed, or more.
-        /// <para>
-        /// Note that if the data of this cloud event was set using the <see cref="BinaryData"/>
-        /// property, then the value of <em>this</em> property is that binary value, base-64
-        /// encoded.
-        /// </para>
         /// </summary>
         public string StringData
         {
@@ -284,21 +278,12 @@ namespace RockLib.Messaging.CloudEvents
                         return Convert.ToBase64String((byte[])_data);
                 }
             }
-            set
-            {
-                if (value != StringData)
-                    _data = value;
-            }
         }
 
         /// <summary>
         /// Domain-specific information about the occurrence (i.e. the payload) as a byte array.
         /// This might include information about the occurrence, details about the data that was
         /// changed, or more.
-        /// <para>
-        /// Note that if the data of this cloud event was set using the <see cref="StringData"/>
-        /// property, then the value of <em>this</em> property is that string value, utf-8 encoded.
-        /// </para>
         /// </summary>
         public byte[] BinaryData
         {
@@ -313,18 +298,6 @@ namespace RockLib.Messaging.CloudEvents
                     default:
                         return Encoding.UTF8.GetBytes((string)_data);
                 }
-            }
-            set
-            {
-                if (ReferenceEquals(_data, value))
-                    return;
-                
-                var binaryData = BinaryData;
-
-                if (binaryData != null && value != null && binaryData.SequenceEqual(value))
-                    return;
-
-                _data = value;
             }
         }
 
@@ -599,6 +572,10 @@ namespace RockLib.Messaging.CloudEvents
             value = default;
             return false;
         }
+
+        internal void SetDataField(string data) => _data = data;
+
+        internal void SetDataField(byte[] data) => _data = data;
 
         private string IdHeader => ProtocolBinding.GetHeaderName(IdAttribute);
 

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -201,6 +201,7 @@ namespace RockLib.Messaging.CloudEvents
         /// information such as the type of the event source, the organization publishing the event
         /// or the process that produced the event. The exact syntax and semantics behind the data
         /// encoded in the URI is defined by the event producer.
+        /// <para>Must be a valid relative or absolute URI.</para>
         /// </summary>
         public string Source
         {
@@ -229,6 +230,7 @@ namespace RockLib.Messaging.CloudEvents
 
         /// <summary>
         /// Content type of data value.
+        /// <para>Must be a valid Content-Type value according to RFC 2616.</para>
         /// </summary>
         public string DataContentType
         {
@@ -244,6 +246,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <summary>
         /// Identifies the schema that data adheres to. Incompatible changes to the schema SHOULD be
         /// reflected by a different URI.
+        /// <para>Must be a valid relative or absolute URI.</para>
         /// </summary>
         public string DataSchema
         {
@@ -280,51 +283,28 @@ namespace RockLib.Messaging.CloudEvents
         }
 
         /// <summary>
+        /// Any additional attributes not specific to this CloudEvent type.
+        /// </summary>
+        public IDictionary<string, object> AdditionalAttributes { get; } = new Dictionary<string, object>();
+
+        /// <summary>
         /// Domain-specific information about the occurrence (i.e. the payload) as a string. This
         /// might include information about the occurrence, details about the data that was
         /// changed, or more.
+        /// <para>To set this value, call either the <see cref="CloudEventExtensions
+        /// .SetData{TCloudEvent}(TCloudEvent, string)"/> or <see cref="CloudEventExtensions
+        /// .SetData{TCloudEvent, T}(TCloudEvent, T, DataSerialization)"/> extension method.</para>
         /// </summary>
-        public string StringData
-        {
-            get
-            {
-                switch (_data)
-                {
-                    case string stringData:
-                        return stringData;
-                    case null:
-                        return null;
-                    default:
-                        return Convert.ToBase64String((byte[])_data);
-                }
-            }
-        }
+        public string StringData => _data as string;
 
         /// <summary>
         /// Domain-specific information about the occurrence (i.e. the payload) as a byte array.
         /// This might include information about the occurrence, details about the data that was
         /// changed, or more.
+        /// <para>To set this value, call the <see cref="CloudEventExtensions.SetData{TCloudEvent}(
+        /// TCloudEvent, byte[])"/> extension method.</para>
         /// </summary>
-        public byte[] BinaryData
-        {
-            get
-            {
-                switch (_data)
-                {
-                    case byte[] binaryData:
-                        return binaryData;
-                    case null:
-                        return null;
-                    default:
-                        return Encoding.UTF8.GetBytes((string)_data);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Any additional attributes not specific to this CloudEvent type.
-        /// </summary>
-        public IDictionary<string, object> AdditionalAttributes { get; } = new Dictionary<string, object>();
+        public byte[] BinaryData => _data as byte[];
 
         /// <summary>
         /// Creates a <see cref="SenderMessage"/> with headers mapped from the attributes of this cloud event.

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -577,6 +577,8 @@ namespace RockLib.Messaging.CloudEvents
 
         internal void SetDataField(byte[] data) => _data = data;
 
+        internal void ClearDataField() => _data = null;
+
         private string IdHeader => ProtocolBinding.GetHeaderName(IdAttribute);
 
         private string SourceHeader => ProtocolBinding.GetHeaderName(SourceAttribute);

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using RockLib.Messaging.DependencyInjection;
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace RockLib.Messaging.CloudEvents
@@ -13,6 +14,29 @@ namespace RockLib.Messaging.CloudEvents
         private static readonly ConcurrentDictionary<Type, CopyConstructor> _copyConstructors = new ConcurrentDictionary<Type, CopyConstructor>();
         private static readonly ConcurrentDictionary<Type, MessageConstructor> _messageConstructors = new ConcurrentDictionary<Type, MessageConstructor>();
         private static readonly ConcurrentDictionary<Type, ValidateMethod> _validateMethods = new ConcurrentDictionary<Type, ValidateMethod>();
+
+        public static TCloudEvent SetData<TCloudEvent>(this TCloudEvent cloudEvent, string data)
+            where TCloudEvent : CloudEvent
+        {
+            if (data != cloudEvent.StringData)
+                cloudEvent.SetDataField(data);
+
+            return cloudEvent;
+        }
+
+        public static TCloudEvent SetData<TCloudEvent>(this TCloudEvent cloudEvent, byte[] data)
+            where TCloudEvent : CloudEvent
+        {
+            var binaryData = cloudEvent.BinaryData;
+
+            if (!ReferenceEquals(binaryData, data)
+                && (binaryData == null || data == null || !binaryData.SequenceEqual(data)))
+            {
+                cloudEvent.SetDataField(data);
+            }
+
+            return cloudEvent;
+        }
 
         /// <summary>
         /// Creates a new instance of the <typeparamref name="TCloudEvent"/> type and copies all

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -119,11 +119,9 @@ namespace RockLib.Messaging.CloudEvents
                     case DataSerialization.Json:
                         cloudEvent.SetDataField(JsonSerialize(data));
                         break;
-                    case DataSerialization.Xml:
+                    default:
                         cloudEvent.SetDataField(XmlSerialize(data));
                         break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(serialization));
                 }
                 cloudEvent.SetDataObject(data);
             }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -25,9 +25,9 @@ namespace RockLib.Messaging.CloudEvents
         /// <summary>
         /// Sets the data (payload) of the <see cref="CloudEvent"/> as type <see cref="string"/>.
         /// <para>
-        /// After calling this method, the <see cref="CloudEvent.StringData"/> property will return
-        /// the value of <paramref name="data"/>, and the <see cref="CloudEvent.BinaryData"/>
-        /// property will return the utf-8 encoded value of <paramref name="data"/>.
+        /// After calling this method, the <see cref="CloudEvent.StringData"/> property returns
+        /// <paramref name="data"/>, and the <see cref="CloudEvent.BinaryData"/> property returns
+        /// <see langword="null"/>.
         /// </para>
         /// </summary>
         /// <typeparam name="TCloudEvent">The type of <see cref="CloudEvent"/>.</typeparam>
@@ -57,9 +57,9 @@ namespace RockLib.Messaging.CloudEvents
         /// <summary>
         /// Sets the data (payload) of the <see cref="CloudEvent"/> as a <see cref="byte"/> array.
         /// <para>
-        /// After calling this method, the <see cref="CloudEvent.BinaryData"/> property will return
-        /// the value of <paramref name="data"/>, and the <see cref="CloudEvent.StringData"/>
-        /// property will return the base-64 encoded value of <paramref name="data"/>.
+        /// After calling this method, the <see cref="CloudEvent.BinaryData"/> property returns
+        /// <paramref name="data"/>, and the <see cref="CloudEvent.StringData"/> property returns
+        /// <see langword="null"/>.
         /// </para>
         /// </summary>
         /// <typeparam name="TCloudEvent">The type of <see cref="CloudEvent"/>.</typeparam>
@@ -93,9 +93,9 @@ namespace RockLib.Messaging.CloudEvents
         /// Sets the data (payload) of the <see cref="CloudEvent"/> as type <typeparamref name=
         /// "T"/>.
         /// <para>
-        /// After calling this method, the <see cref="CloudEvent.StringData"/> property will return
-        /// the serialized value of <paramref name="data"/>, and the <see cref="CloudEvent.BinaryData"/>
-        /// property will return that serialized value, utf-8 encoded.
+        /// After calling this method, the <see cref="CloudEvent.StringData"/> property returns
+        /// the JSON or XML serialized <paramref name="data"/>, and the <see cref=
+        /// "CloudEvent.BinaryData"/> property returns <see langword="null"/>.
         /// </para>
         /// <para>
         /// The same instance of <typeparamref name="T"/> can be retrieved by calling the <see cref

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -24,6 +24,11 @@ namespace RockLib.Messaging.CloudEvents
 
         /// <summary>
         /// Sets the data (payload) of the <see cref="CloudEvent"/> as type <see cref="string"/>.
+        /// <para>
+        /// After calling this method, the <see cref="CloudEvent.StringData"/> property will return
+        /// the value of <paramref name="data"/>, and the <see cref="CloudEvent.BinaryData"/>
+        /// property will return the utf-8 encoded value of <paramref name="data"/>.
+        /// </para>
         /// </summary>
         /// <typeparam name="TCloudEvent">The type of <see cref="CloudEvent"/>.</typeparam>
         /// <param name="cloudEvent">The <see cref="CloudEvent"/> to set the data to.</param>
@@ -51,6 +56,11 @@ namespace RockLib.Messaging.CloudEvents
 
         /// <summary>
         /// Sets the data (payload) of the <see cref="CloudEvent"/> as a <see cref="byte"/> array.
+        /// <para>
+        /// After calling this method, the <see cref="CloudEvent.BinaryData"/> property will return
+        /// the value of <paramref name="data"/>, and the <see cref="CloudEvent.StringData"/>
+        /// property will return the base-64 encoded value of <paramref name="data"/>.
+        /// </para>
         /// </summary>
         /// <typeparam name="TCloudEvent">The type of <see cref="CloudEvent"/>.</typeparam>
         /// <param name="cloudEvent">The <see cref="CloudEvent"/> to set the data to.</param>
@@ -82,6 +92,16 @@ namespace RockLib.Messaging.CloudEvents
         /// <summary>
         /// Sets the data (payload) of the <see cref="CloudEvent"/> as type <typeparamref name=
         /// "T"/>.
+        /// <para>
+        /// After calling this method, the <see cref="CloudEvent.StringData"/> property will return
+        /// the serialized value of <paramref name="data"/>, and the <see cref="CloudEvent.BinaryData"/>
+        /// property will return that serialized value, utf-8 encoded.
+        /// </para>
+        /// <para>
+        /// The same instance of <typeparamref name="T"/> can be retrieved by calling the <see cref
+        /// ="GetData"/> and <see cref="TryGetData"/> methods with the same instance of <see cref=
+        /// "CloudEvent"/> and the same type parameter <typeparamref name="T"/>.
+        /// </para>
         /// </summary>
         /// <typeparam name="TCloudEvent">The type of <see cref="CloudEvent"/>.</typeparam>
         /// <typeparam name="T">The type of the <see cref="CloudEvent"/> data.</typeparam>
@@ -138,6 +158,13 @@ namespace RockLib.Messaging.CloudEvents
         /// cref="CloudEvent"/> and the <em>same type</em> <typeparamref name="T"/> will return the
         /// <em>same instance</em> of type <typeparamref name="T"/>.
         /// </para>
+        /// <para>
+        /// If the data object of this cloud event was set using the <see cref=
+        /// "SetData{TCloudEvent, T}(TCloudEvent, T, DataSerialization)"/> method, then the same
+        /// instance of <typeparamref name="T"/> that was passed to that method will be returned by
+        /// this method. Otherwise, the value of <see cref="CloudEvent.StringData"/> is used to
+        /// deserialize the instance of <typeparamref name="T"/>.
+        /// </para>
         /// </summary>
         /// <typeparam name="T">The type of the <see cref="CloudEvent"/> data.</typeparam>
         /// <param name="cloudEvent">The <see cref="CloudEvent"/> to get data from.</param>
@@ -191,6 +218,13 @@ namespace RockLib.Messaging.CloudEvents
         /// other words, every call to either of these methods with <em>same instance</em> of <see
         /// cref="CloudEvent"/> and the <em>same type</em> <typeparamref name="T"/> will return the
         /// <em>same instance</em> of type <typeparamref name="T"/>.
+        /// </para>
+        /// <para>
+        /// If the data object of this cloud event was set using the <see cref=
+        /// "SetData{TCloudEvent, T}(TCloudEvent, T, DataSerialization)"/> method, then the same
+        /// instance of <typeparamref name="T"/> that was passed to that method will be returned by
+        /// this method. Otherwise, the value of <see cref="CloudEvent.StringData"/> is used to
+        /// deserialize the instance of <typeparamref name="T"/>.
         /// </para>
         /// </summary>
         /// <typeparam name="T">The type of the <see cref="CloudEvent"/> data.</typeparam>

--- a/RockLib.Messaging.CloudEvents/DataSerialization.cs
+++ b/RockLib.Messaging.CloudEvents/DataSerialization.cs
@@ -1,0 +1,19 @@
+﻿namespace RockLib.Messaging.CloudEvents
+{
+    /// <summary>
+    /// Defines types of serialization to use when getting or setting the data of a <see cref=
+    /// "CloudEvent"/> as a generic type.
+    /// </summary>
+    public enum DataSerialization
+    {
+        /// <summary>
+        /// JSON serialization.
+        /// </summary>
+        Json,
+
+        /// <summary>
+        /// XML serialization.
+        /// </summary>
+        Xml
+    }
+}


### PR DESCRIPTION
- Replaces the setters from `StringData` and `BinaryData` properties with `SetData` extension methods.
- The getters from `StringData` and `BinaryData` don't do any utf-8/base-64 encoding/decoding; they return null if the event's data doesn't match the type of the property.
- Adds generic `SetData`, `GetData` and `TryGetData` methods, each with an optional `DataSerialization` enum parameter (values: `Json` and `Xml`).
- Changes the type of the `Source`, `DataContentType`, and `DataSchema` properties to type `string`. Each of the property setters throws if the value is not a valid URI or Content-Type.