### PR TITLE
Add Support for Message Schema Validation

### DIFF
--- a/RockLib.Messaging.Kafka/DependencyInjection/KafkaSenderOptions.cs
+++ b/RockLib.Messaging.Kafka/DependencyInjection/KafkaSenderOptions.cs
@@ -21,6 +21,11 @@ namespace RockLib.Messaging.Kafka.DependencyInjection
         /// Gets or sets the topic to subscribe to.
         /// </summary>
         public string Topic { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the schema ID to validate messages against
+        /// </summary>
+        public int SchemaId { get; set; }
     }
 }
 #endif

--- a/RockLib.Messaging.Kafka/KafkaSender.cs
+++ b/RockLib.Messaging.Kafka/KafkaSender.cs
@@ -75,7 +75,11 @@ namespace RockLib.Messaging.Kafka
         /// </summary>
         /// <param name="name">The name of the sender.</param>
         /// <param name="topic">The topic to produce messages to.</param>
-        /// <param name="schemaId">The schema ID to have the broker validate messages against.</param>
+        /// <param name="schemaId">
+        /// The schema ID to have the broker validate messages against. The sender will prepend a leading empty byte
+        /// and the schema ID to the payload according to the Confluent 
+        /// <a href="https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#wire-format">wire format</a>.
+        /// </param>
         /// <param name="bootstrapServers">List of brokers as a CSV list of broker host or host:port.</param>
         /// <param name="messageTimeoutMs">
         /// Local message timeout. This value is only enforced locally and limits the time
@@ -143,7 +147,9 @@ namespace RockLib.Messaging.Kafka
         public event EventHandler<ErrorEventArgs> Error;
 
         /// <summary>
-        /// Determine if the message should include the schema ID for validation
+        /// Determine if the message should include the schema ID for validation. When <code>true</code> the sender
+        /// prepends an empty byte and the schema ID to the payload according to the Confluent
+        /// <a href="https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#wire-format">wire format</a>.
         /// </summary>
         private bool ShouldIncludeSchemaId => SchemaId > 0;
 

--- a/Tests/RockLib.Messaging.Kafka.Tests/KafkaSenderTests.cs
+++ b/Tests/RockLib.Messaging.Kafka.Tests/KafkaSenderTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Xunit;
 using System;
+using System.Net;
 using Confluent.Kafka;
 using RockLib.Dynamic;
 using Moq;
@@ -26,6 +27,7 @@ namespace RockLib.Messaging.Kafka.Tests
             sender.BootstrapServers.Should().Be(servers);
             sender.MessageTimeoutMs.Should().Be(timeout);
             sender.Producer.Should().NotBeNull();
+            sender.SchemaId.Should().BeNull();
         }
 
         [Fact(DisplayName = "KafkaSender constructor 2 sets appropriate properties")]
@@ -47,6 +49,25 @@ namespace RockLib.Messaging.Kafka.Tests
             sender.BootstrapServers.Should().Be(servers);
             sender.MessageTimeoutMs.Should().Be(timeout);
             sender.Producer.Should().NotBeNull();
+            sender.SchemaId.Should().BeNull();
+        }
+        
+        [Fact(DisplayName = "KafkaSender constructor 3 sets appropriate properties")]
+        public void KafkaSenderConstructor3HappyPath()
+        {
+            var name = "name";
+            var topic = "topic";
+            var servers = "bootstrapServers";
+            var timeout = 100;
+            var schemaId = 10;
+            var sender = new KafkaSender(name, topic, schemaId, servers, timeout);
+
+            sender.Name.Should().Be(name);
+            sender.Topic.Should().Be(topic);
+            sender.BootstrapServers.Should().Be(servers);
+            sender.MessageTimeoutMs.Should().Be(timeout);
+            sender.Producer.Should().NotBeNull();
+            sender.SchemaId.Should().Be(schemaId);
         }
 
         [Fact(DisplayName = "KafkaSender constructor throws on null name")]
@@ -90,9 +111,38 @@ namespace RockLib.Messaging.Kafka.Tests
             Action action = () => new KafkaSender("name", "topic", null);
             action.Should().Throw<ArgumentNullException>();
         }
+        
+        [Fact(DisplayName = "KafkaSender constructor 3 throws on null name")]
+        public void KafkaSenderConstructor3SadPath1()
+        {
+            Action action = () => new KafkaSender(null, "topic", 10, "boostrapServers");
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact(DisplayName = "KafkaSender constructor 3 throws on null topic")]
+        public void KafkaSenderConstructor3SadPath2()
+        {
+            Action action = () => new KafkaSender("name", null, 10, "boostrapServers");
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        
+        [Fact(DisplayName = "KafkaSender constructor 3 throws on negative schemaId")]
+        public void KafkaSenderConstructor3SadPath4()
+        {
+            Action action = () => new KafkaSender("name", "topic", -1, "bootstrapServers");
+            action.Should().Throw<ArgumentOutOfRangeException>();
+        }
+        
+        [Fact(DisplayName = "KafkaSender constructor 3 throws on null bootstrapServers")]
+        public void KafkaSenderConstructor3SadPath3()
+        {
+            Action action = () => new KafkaSender("name", "topic", 10, null);
+            action.Should().Throw<ArgumentNullException>();
+        }
 
         [Fact(DisplayName = "KafkaSender SendAsync sets OriginatingSystem to Kafka and sets message")]
-        public async Task KafkaSenderSendAsyncHappyPath()
+        public async Task KafkaSenderSendAsyncHappyPath1()
         {
             var message = "This is a message";
             var producerMock = new Mock<IProducer<string, byte[]>>();
@@ -108,6 +158,31 @@ namespace RockLib.Messaging.Kafka.Tests
             producerMock.Verify(pm => pm.ProduceAsync("topic", 
                 It.Is<Message<string, byte[]>>(m => Encoding.UTF8.GetString(m.Value) == message && Encoding.UTF8.GetString(m.Headers[1].GetValueBytes()) == "Kafka"), 
                 It.IsAny<CancellationToken>()));
+        }
+        
+        [Fact(DisplayName = "KafkaSender SendAsync adds schema ID to message payload when available")]
+        public async Task KafkaSenderSendAsyncHappyPath2()
+        {
+            var message = "This is a message";
+            var schemaId = 100;
+            var producerMock = new Mock<IProducer<string, byte[]>>();
+            Message<string, byte[]> sentMessage = null;
+            producerMock
+                .Setup(pm => pm.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, byte[]>>(), It.IsAny<CancellationToken>()))
+                .Callback<string, Message<string, byte[]>, CancellationToken>((str, msg, ct) => sentMessage = msg)
+                .ReturnsAsync((DeliveryResult<string, byte[]>)null);
+
+            var sender = new KafkaSender("name", "topic", schemaId, "servers");
+            sender.Unlock()._producer = new Lazy<IProducer<string, byte[]>>(() => producerMock.Object);
+
+            await sender.SendAsync(new SenderMessage(message));
+            
+            Assert.Equal(0, BitConverter.ToInt32(sentMessage.Value, 0));
+            Assert.Equal(schemaId, IPAddress.NetworkToHostOrder(BitConverter.ToInt32(sentMessage.Value, 1)));
+            
+            var memory = new Memory<byte>(sentMessage.Value, 5, sentMessage.Value.Length - 5);
+            Assert.Equal(message, Encoding.UTF8.GetString(memory.ToArray()));
+            Assert.Equal("Kafka", Encoding.UTF8.GetString(sentMessage.Headers[1].GetValueBytes()));
         }
 
         [Fact(DisplayName = "KafkaSender Dispose calls Flush and Dispose on producer")]

--- a/docs/Kafka.md
+++ b/docs/Kafka.md
@@ -17,7 +17,7 @@ The first has the following parameters:
 - messageTimeoutMs (optional, defaults to 10000)
   - Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
 
-And the second has the following parameters:
+The second has the following parameters:
 
 - name
   - The name of the instance of KafkaSender.
@@ -26,6 +26,19 @@ And the second has the following parameters:
 - producerConfig
   - The configuration used in creation of the Kafka producer.
 
+The third has the following parameters:
+
+- name
+  - The name of the instance of KafkaSender.
+- topic
+  - The topic to produce messages to.
+- bootstrapServers
+  - List of brokers as a CSV list of broker host or host:port.
+- schemaId
+  - Schema ID for broker to validate message schema against
+- messageTimeoutMs (optional, defaults to 10000)
+  - Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
+  
 ---
 
 To add an KafkaSender to a service collection for dependency injection, use the `AddKafkaSender` method, optionally passing in a `configureOptions` callback:
@@ -53,7 +66,8 @@ public void ConfigureServices(IServiceCollection services)
     "MyKafkaSender": {
         "Topic": "test",
         "BootstrapServers": "localhost:9092",
-        "MessageTimeoutMs": 10000
+        "MessageTimeoutMs": 10000,
+        "SchemaId": 7890
     }
 }
 */
@@ -72,7 +86,8 @@ MessagingScenarioFactory can be configured with an `KafkaSender` named "commands
                 "Name": "commands",
                 "Topic": "test",
                 "BootstrapServers": "localhost:9092",
-                "MessageTimeoutMs": 10000
+                "MessageTimeoutMs": 10000,
+                "SchemaId": 1234
             }
         }
     }


### PR DESCRIPTION
In order for the Kafka broker to validate the message schema, an empty byte + the schema ID is required in the payload in the leading 5 bytes. This is based on the Confluent [wire format](https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#wire-format).