### PR TITLE
Fix resolver bug

### DIFF
--- a/RockLib.Messaging/DependencyInjection/MessagingExtensions.cs
+++ b/RockLib.Messaging/DependencyInjection/MessagingExtensions.cs
@@ -40,10 +40,15 @@ namespace RockLib.Messaging.DependencyInjection
             return services.AddSender(serviceProvider =>
             {
                 var messagingSection = GetMessagingSection(serviceProvider);
-                var resolver = new Resolver(serviceProvider.GetService);
+                var resolver = new Resolver(serviceProvider.GetService, CanResolve);
 
                 return messagingSection.CreateSender(senderName, resolver: resolver);
             }, lifetime);
+
+            bool CanResolve(Type type) =>
+                type != typeof(ISender)
+                && type != typeof(SenderLookup)
+                && services.Any(s => s.ServiceType == type);
         }
 
         /// <summary>
@@ -150,10 +155,15 @@ namespace RockLib.Messaging.DependencyInjection
             return services.AddTransactionalSender(serviceProvider =>
             {
                 var messagingSection = GetMessagingSection(serviceProvider);
-                var resolver = new Resolver(serviceProvider.GetService);
+                var resolver = new Resolver(serviceProvider.GetService, CanResolve);
 
                 return (ITransactionalSender)messagingSection.CreateSender(senderName, resolver: resolver);
             }, lifetime);
+
+            bool CanResolve(Type type) =>
+                type != typeof(ITransactionalSender)
+                && type != typeof(TransactionalSenderLookup)
+                && services.Any(s => s.ServiceType == type);
         }
 
         /// <summary>
@@ -204,10 +214,15 @@ namespace RockLib.Messaging.DependencyInjection
             return services.AddReceiver(serviceProvider =>
             {
                 var messagingSection = GetMessagingSection(serviceProvider);
-                var resolver = new Resolver(serviceProvider.GetService);
+                var resolver = new Resolver(serviceProvider.GetService, CanResolve);
 
                 return messagingSection.CreateReceiver(receiverName, resolver: resolver);
             }, lifetime);
+
+            bool CanResolve(Type type) =>
+                type != typeof(IReceiver)
+                && type != typeof(ReceiverLookup)
+                && services.Any(s => s.ServiceType == type);
         }
 
         /// <summary>

--- a/Tests/RockLib.Messaging.Tests/RockLib.Messaging.Tests.csproj
+++ b/Tests/RockLib.Messaging.Tests/RockLib.Messaging.Tests.csproj
@@ -24,6 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="CustomConfigFiles\SingleSender_appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Tests/RockLib.Messaging.Tests/appsettings.json
+++ b/Tests/RockLib.Messaging.Tests/appsettings.json
@@ -1,0 +1,36 @@
+{
+  "RockLib.Messaging": {
+    "Senders": [
+      {
+        "Type": "RockLib.Messaging.Tests.FakeSender, RockLib.Messaging.Tests",
+        "Value": {
+          "Name": "MyFakeSender",
+          "PipeName": "MyPipeName"
+        }
+      },
+      {
+        "Type": "RockLib.Messaging.Tests.MessagingExtensionsTests+TestSenderDecorator, RockLib.Messaging.Tests",
+        "Value": {
+          "Name": "MyTestSenderDecorator",
+          "SenderName": "MyFakeSender"
+        }
+      }
+    ],
+    "Receivers": [
+      {
+        "Type": "RockLib.Messaging.Tests.FakeReceiver, RockLib.Messaging.Tests",
+        "Value": {
+          "Name": "MyFakeReceiver",
+          "PipeName": "MyPipeName"
+        }
+      },
+      {
+        "Type": "RockLib.Messaging.Tests.MessagingExtensionsTests+TestReceiverDecorator, RockLib.Messaging.Tests",
+        "Value": {
+          "Name": "MyTestReceiverDecorator",
+          "ReceiverName": "MyFakeReceiver"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
When retrieving a messaging service, we could get stuck in an infinite
recursion/loop situation in configuration object factory. To fix, pass
a 'canResolve' callback to the Resolver constructor.