### PR TITLE
SQS - Reset visibility timeout on rollback

### DIFF
--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+- Adds ability to terminate the message visibility timeout when rolling back.
+
 #### 2.2.9
 
 - Adds `reloadOnChange` parameter to DI extension methods.

--- a/RockLib.Messaging.SQS/DependencyInjection/SQSExtensions.cs
+++ b/RockLib.Messaging.SQS/DependencyInjection/SQSExtensions.cs
@@ -74,7 +74,8 @@ namespace RockLib.Messaging.DependencyInjection
                         : serviceProvider.GetService<IAmazonSQS>() ?? new AmazonSQSClient());
 
                 return new SQSReceiver(sqsClient, name, options.QueueUrl, options.MaxMessages,
-                    options.AutoAcknowledge, options.WaitTimeSeconds, options.UnpackSNS);
+                    options.AutoAcknowledge, options.WaitTimeSeconds, options.UnpackSNS,
+                    options.TerminateMessageVisibilityTimeoutOnRollback);
             }
         }
 

--- a/RockLib.Messaging.SQS/DependencyInjection/SQSReceiverOptions.cs
+++ b/RockLib.Messaging.SQS/DependencyInjection/SQSReceiverOptions.cs
@@ -2,6 +2,7 @@
 using Amazon.SQS;
 using RockLib.Messaging.SQS;
 using System;
+using System.Threading;
 
 namespace RockLib.Messaging.DependencyInjection
 {
@@ -77,6 +78,14 @@ namespace RockLib.Messaging.DependencyInjection
         /// SNS message.
         /// </summary>
         public bool UnpackSNS { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether to terminate the message visibility timeout when
+        /// <see cref="SQSReceiverMessage.RollbackMessageAsync(CancellationToken)"/> is called.
+        /// Terminating the message visibility timeout allows the message to immediately become
+        /// available for queue consumers to process.
+        /// </summary>
+        public bool TerminateMessageVisibilityTimeoutOnRollback { get; set; }
     }
 }
 #endif

--- a/Tests/RockLib.Messaging.SQS.Tests/DependencyInjectionTests.cs
+++ b/Tests/RockLib.Messaging.SQS.Tests/DependencyInjectionTests.cs
@@ -103,6 +103,7 @@ namespace RockLib.Messaging.SQS.Tests
                 options.AutoAcknowledge = false;
                 options.WaitTimeSeconds = 123;
                 options.UnpackSNS = true;
+                options.TerminateMessageVisibilityTimeoutOnRollback = true;
             }, false);
 
             var serviceProvider = services.BuildServiceProvider();
@@ -118,6 +119,7 @@ namespace RockLib.Messaging.SQS.Tests
             sqsReceiver.AutoAcknwoledge.Should().BeFalse();
             sqsReceiver.WaitTimeSeconds.Should().Be(123);
             sqsReceiver.UnpackSNS.Should().BeTrue();
+            sqsReceiver.TerminateMessageVisibilityTimeoutOnRollback.Should().BeTrue();
         }
 
         [Fact]
@@ -137,6 +139,7 @@ namespace RockLib.Messaging.SQS.Tests
                 options.AutoAcknowledge = false;
                 options.WaitTimeSeconds = 123;
                 options.UnpackSNS = true;
+                options.TerminateMessageVisibilityTimeoutOnRollback = true;
             }, true);
 
             var serviceProvider = services.BuildServiceProvider();
@@ -154,6 +157,7 @@ namespace RockLib.Messaging.SQS.Tests
             sqsReceiver.AutoAcknwoledge.Should().BeFalse();
             sqsReceiver.WaitTimeSeconds.Should().Be(123);
             sqsReceiver.UnpackSNS.Should().BeTrue();
+            sqsReceiver.TerminateMessageVisibilityTimeoutOnRollback.Should().BeTrue();
         }
 
         [Fact(DisplayName = "Should register SQS receiver with registered SQS client when available")]

--- a/docs/SQS.md
+++ b/docs/SQS.md
@@ -104,10 +104,12 @@ The SQSReceiver class can be directly instantiated and has the following paramet
   - The duration (in seconds) for which calls to ReceiveMessage wait for a message to arrive in the queue before returning. If a message is available, the call returns sooner than WaitTimeSeconds. If no messages are available and the wait time expires, the call returns successfully with an empty list of messages.
 - unpackSNS (optional, defaults to false)
   - Whether to attempt to unpack the message body as an SNS message.
+- terminateMessageVisibilityTimeoutOnRollback (optional, defaults to false)
+  - Whether to terminate the message visibility timeout when SQSReceiverMessage.RollbackMessageAsync is called. Terminating the message visibility timeout allows the message to immediately become available for queue consumers to process.
 
 ```c#
 IReceiver receiver = new SQSReceiver("MyReceiver", "https://sqs.us-west-2.amazonaws.com/123456789012/your_queue_name",
-    region:"us-west-2", maxMessages: 3, autoAcknowledge: true, waitTimeSeconds: 0, unpackSNS: false);
+    region:"us-west-2", maxMessages: 3, autoAcknowledge: true, waitTimeSeconds: 0, unpackSNS: false, terminateMessageVisibilityTimeoutOnRollback: false);
 ```
 
 ---
@@ -123,6 +125,7 @@ services.AddSQSReceiver("MySender", options =>
     options.AutoAcknowledge = true;
     options.WaitTimeSeconds = 0;
     options.UnpackSNS = false;
+    options.TerminateMessageVisibilityTimeoutOnRollback = false;
 });
 ```
 
@@ -143,7 +146,8 @@ public void ConfigureServices(IServiceCollection services)
     "MaxMessages": 3,
     "AutoAcknowledge": true,
     "WaitTimeSeconds": 0,
-    "UnpackSNS": false
+    "UnpackSNS": false,
+    "TerminateMessageVisibilityTimeoutOnRollback": false
   }
 }
 */
@@ -165,7 +169,8 @@ MessagingScenarioFactory can be configured with an `SQSReceiver` named "commands
                 "MaxMessages": 3,
                 "AutoAcknowledge": true,
                 "WaitTimeSeconds": 0,
-                "UnpackSNS": false
+                "UnpackSNS": false,
+                "TerminateMessageVisibilityTimeoutOnRollback": false
             }
         }
     }


### PR DESCRIPTION
Add the ability to reset a sqs message's visibility timeout when the
message is rolled back.

When rolling back a message, the intent is generally to retry the
message. Currently, the message will not be retried until the
visibility timeout expires. While this may be suitable in some cases,
it can cause added queue pressure in fifo queues since any messages
still in the queue with the same group id would be held up. Terminating
the visibility timeout on rollback allows the message to become
immediately available for queue consumers.