### PR TITLE
Feature - Kafka Sender & Receiver Statistics

### DIFF
--- a/RockLib.Messaging.Kafka/KafkaSender.cs
+++ b/RockLib.Messaging.Kafka/KafkaSender.cs
@@ -43,6 +43,7 @@ namespace RockLib.Messaging.Kafka
 
             var producerBuilder = new ProducerBuilder<string, byte[]>(config);
             producerBuilder.SetErrorHandler(OnError);
+            producerBuilder.SetStatisticsHandler(OnStatisticsEmitted);
 
             _producer = new Lazy<IProducer<string, byte[]>>(() => producerBuilder.Build());
         }
@@ -65,6 +66,7 @@ namespace RockLib.Messaging.Kafka
 
             var producerBuilder = new ProducerBuilder<string, byte[]>(producerConfig);
             producerBuilder.SetErrorHandler(OnError);
+            producerBuilder.SetStatisticsHandler(OnStatisticsEmitted);
 
             _producer = new Lazy<IProducer<string, byte[]>>(() => producerBuilder.Build());
         }
@@ -102,6 +104,7 @@ namespace RockLib.Messaging.Kafka
 
             var producerBuilder = new ProducerBuilder<string, byte[]>(config);
             producerBuilder.SetErrorHandler(OnError);
+            producerBuilder.SetStatisticsHandler(OnStatisticsEmitted);
 
             _producer = new Lazy<IProducer<string, byte[]>>(() => producerBuilder.Build());
         }
@@ -163,6 +166,12 @@ namespace RockLib.Messaging.Kafka
         /// Occurs when an error happens on a background thread.
         /// </summary>
         public event EventHandler<ErrorEventArgs> Error;
+        
+        /// <summary>
+        /// Occurs when the Kafka producer emits statistics. The statistics is a JSON formatted string as defined here:
+        /// <a href="https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md">https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md</a>
+        /// </summary>
+        public event EventHandler<string> StatisticsEmitted;
 
         /// <summary>
         /// Determine if the message should include the schema ID for validation. When <code>true</code> the sender
@@ -256,6 +265,14 @@ namespace RockLib.Messaging.Kafka
                 binaryWriter.Write(message.BinaryPayload);
                 return memoryStream.ToArray();
             }
+        }
+
+        /// <summary>
+        /// Callback for the Kafka producer. Invokes the <see cref="StatisticsEmitted"/> event.
+        /// </summary>
+        private void OnStatisticsEmitted(IProducer<string, byte[]> producer, string statistics)
+        {
+            StatisticsEmitted?.Invoke(this, statistics);
         }
     }
 }

--- a/RockLib.Messaging.Kafka/KafkaSender.cs
+++ b/RockLib.Messaging.Kafka/KafkaSender.cs
@@ -32,14 +32,19 @@ namespace RockLib.Messaging.Kafka
         /// Delivery error occurs when either the retry count or the message timeout are
         /// exceeded.
         /// </param>
-        public KafkaSender(string name, string topic, string bootstrapServers, int messageTimeoutMs = 10000)
+        /// /// <param name="statisticsIntervalMs">
+        /// The statistics emit interval in milliseconds. Granularity is 1,000ms. An event handler must be attached to the
+        /// <see cref="StatisticsEmitted"/> event to receive the statistics data. Setting to 0 disables statistics. 
+        /// </param>
+        public KafkaSender(string name, string topic, string bootstrapServers, int messageTimeoutMs = 10000, 
+            int statisticsIntervalMs = 0)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Topic = topic ?? throw new ArgumentNullException(nameof(topic));
             BootstrapServers = bootstrapServers ?? throw new ArgumentNullException(nameof(bootstrapServers));
             MessageTimeoutMs = messageTimeoutMs;
 
-            var config = GetProducerConfig(bootstrapServers, messageTimeoutMs);
+            var config = GetProducerConfig(bootstrapServers, messageTimeoutMs, statisticsIntervalMs);
 
             var producerBuilder = new ProducerBuilder<string, byte[]>(config);
             producerBuilder.SetErrorHandler(OnError);
@@ -89,7 +94,12 @@ namespace RockLib.Messaging.Kafka
         /// Delivery error occurs when either the retry count or the message timeout are
         /// exceeded.
         /// </param>
-        public KafkaSender(string name, string topic, int schemaId, string bootstrapServers, int messageTimeoutMs = 10000)
+        /// <param name="statisticsIntervalMs">
+        /// The statistics emit interval in milliseconds. Granularity is 1,000ms. An event handler must be attached to the
+        /// <see cref="StatisticsEmitted"/> event to receive the statistics data. Setting to 0 disables statistics.
+        /// </param>
+        public KafkaSender(string name, string topic, int schemaId, string bootstrapServers, int messageTimeoutMs = 10000,
+            int statisticsIntervalMs = 0)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Topic = topic ?? throw new ArgumentNullException(nameof(topic));
@@ -100,7 +110,7 @@ namespace RockLib.Messaging.Kafka
                 throw new ArgumentOutOfRangeException(nameof(schemaId), "Should be greater than 0");
             SchemaId = schemaId;
 
-            var config = GetProducerConfig(bootstrapServers, messageTimeoutMs);
+            var config = GetProducerConfig(bootstrapServers, messageTimeoutMs, statisticsIntervalMs);
 
             var producerBuilder = new ProducerBuilder<string, byte[]>(config);
             producerBuilder.SetErrorHandler(OnError);
@@ -244,12 +254,14 @@ namespace RockLib.Messaging.Kafka
             return Encoding.UTF8.GetBytes(value);
         }
 
-        internal static ProducerConfig GetProducerConfig(string bootstrapServers, int messageTimeoutMs)
+        internal static ProducerConfig GetProducerConfig(string bootstrapServers, int messageTimeoutMs,
+            int statisticsIntervalMs)
         {
             return new ProducerConfig()
             {
                 BootstrapServers = bootstrapServers,
-                MessageTimeoutMs = messageTimeoutMs
+                MessageTimeoutMs = messageTimeoutMs,
+                StatisticsIntervalMs = statisticsIntervalMs
             };
         }
 

--- a/RockLib.Messaging.Kafka/StatisticsExtensions.cs
+++ b/RockLib.Messaging.Kafka/StatisticsExtensions.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Confluent.Kafka;
+using RockLib.Configuration.ObjectFactory;
+
+namespace RockLib.Messaging.Kafka
+{
+    /// <summary>
+    /// Extension methods related to <see cref="KafkaReceiver"/> and <see cref="KafkaSender"/> statistics events
+    /// </summary>
+    public static class StatisticsExtensions
+    {
+        /// <summary>
+        /// Sets a handler for the statistics emitted event of the <see cref="KafkaReceiver"/>.
+        /// <para>
+        /// After setting the event handler, the handler will be called on intervals specified by the
+        /// <see cref="ProducerConfig.StatisticsIntervalMs"/> property.
+        /// </para> 
+        /// </summary>
+        /// <param name="receiver">The <see cref="KafkaReceiver"/> to set the event handler on</param>
+        /// <param name="statisticsEmittedHandler">The event handler to be called when the underlying Consumer emits statistics.
+        /// The statistics is a JSON formatted string as defined here:
+        /// <a href="https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md">https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md</a>
+        /// </param>
+        /// <returns>The same <see cref="IReceiver"/> for method chaining</returns>
+        /// <exception cref="ArgumentNullException">
+        /// If <paramref name="receiver"/> or <paramref name="statisticsEmittedHandler"/> is <see langword="null"/>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="receiver"/> is not a <see cref="KafkaReceiver"/>
+        /// </exception>
+        public static IReceiver AddStatisticsEmittedHandler(this IReceiver receiver, EventHandler<string> statisticsEmittedHandler)
+        {
+            if (receiver is null)
+                throw new ArgumentNullException(nameof(receiver));
+            if (statisticsEmittedHandler is null)
+                throw new ArgumentNullException(nameof(statisticsEmittedHandler));
+            
+            var kafkaReceiver = (receiver as ConfigReloadingProxy<IReceiver>)?.Object as KafkaReceiver;
+            kafkaReceiver = kafkaReceiver ?? receiver as KafkaReceiver;
+
+            if (kafkaReceiver is null)
+                throw new ArgumentException(
+                    $"Receiver should be of type {nameof(KafkaReceiver)} or a proxy class wrapping {nameof(KafkaReceiver)}",
+                    nameof(receiver));
+
+            kafkaReceiver.StatisticsEmitted += statisticsEmittedHandler;
+            
+            return receiver;
+        }
+        
+        /// <summary>
+        /// Sets a handler for the statistics emitted event of the <see cref="KafkaSender"/>.
+        /// <para>
+        /// After setting the event handler, the handler will be called on intervals specified by the
+        /// <see cref="ConsumerConfig.StatisticsIntervalMs"/> property.
+        /// </para>
+        /// </summary>
+        /// <param name="sender">The <see cref="KafkaSender"/> to set the event handler on</param>
+        /// <param name="statisticsEmittedHandler">The event handler to be called when the underlying Producer emits statistics.
+        /// The statistics is a JSON formatted string as defined here:
+        /// <a href="https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md">https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md</a>
+        /// </param>
+        /// <returns>The same <see cref="ISender"/> for method chaining</returns>
+        /// <exception cref="ArgumentNullException">
+        /// If <paramref name="sender"/> or <paramref name="statisticsEmittedHandler"/> is <see langword="null"/>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="sender"/> is not a <see cref="KafkaSender"/>
+        /// </exception>
+        public static ISender AddStatisticsEmittedHandler(this ISender sender, EventHandler<string> statisticsEmittedHandler)
+        {
+            if (sender is null)
+                throw new ArgumentNullException(nameof(sender));
+            if (statisticsEmittedHandler is null)
+                throw new ArgumentNullException(nameof(statisticsEmittedHandler));
+            
+            var kafkaSender = (sender as ConfigReloadingProxy<ISender>)?.Object as KafkaSender;
+            kafkaSender = kafkaSender ?? sender as KafkaSender;
+
+            if (kafkaSender is null)
+                throw new ArgumentException(
+                    $"Sender should be of type {nameof(KafkaSender)} or a proxy class wrapping {nameof(KafkaSender)}",
+                    nameof(sender));
+
+            kafkaSender.StatisticsEmitted += statisticsEmittedHandler;
+
+            return sender;
+        }
+    }
+}

--- a/Tests/RockLib.Messaging.Kafka.Tests/StatisticsExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.Kafka.Tests/StatisticsExtensionsTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using FluentAssertions;
+using Moq;
+using RockLib.Dynamic;
+using Xunit;
+
+namespace RockLib.Messaging.Kafka.Tests
+{
+    public class StatisticsExtensionsTests
+    {
+        [Fact(DisplayName = "Throws argument null exception for null receiver")]
+        public void ReceiverAddStatisticsEmittedHandlerSadPath1()
+        {
+            Action action = () => ((IReceiver)null).AddStatisticsEmittedHandler((sender, s) => { });
+            action.Should().Throw<ArgumentNullException>();
+        }
+        
+        [Fact(DisplayName = "Throws argument null exception for null event handler")]
+        public void ReceiverAddStatisticsEmittedHandlerSadPath2()
+        {
+            var receiver = new KafkaReceiver("NAME", "TOPIC", "GROUPID", "SERVERS");
+            Action action = () => receiver.AddStatisticsEmittedHandler(null);
+            action.Should().Throw<ArgumentNullException>();
+        }
+        
+        [Fact(DisplayName = "Throws argument exception for non-KafkaReceiver")]
+        public void ReceiverAddStatisticsEmittedHandlerSadPath3()
+        {
+            Action action = () => new Mock<IReceiver>().Object.AddStatisticsEmittedHandler((sender, s) => { });
+            action.Should().Throw<ArgumentException>();
+        }
+
+        [Fact(DisplayName = "Adds event handler to given KafkaReceiver")]
+        public void ReceiverAddStatisticsEmittedHandlerHappyPath()
+        {
+            var receiver = new KafkaReceiver("NAME", "TOPIC", "GROUPID", "SERVERS");
+            var statsData = "STATS!";
+            var callCount = 0;
+
+            void Handler(object sender, string stats)
+            {
+                sender.Should().BeSameAs(receiver);
+                stats.Should().Be(statsData);
+                callCount++;
+            }
+
+            receiver.AddStatisticsEmittedHandler(Handler);
+            receiver.Unlock().OnStatisticsEmitted(null, statsData);
+            
+            callCount.Should().Be(1, "Event handler should have been called");
+        }
+        
+        [Fact(DisplayName = "Throws argument null exception for null sender")]
+        public void SenderAddStatisticsEmittedHandlerSadPath1()
+        {
+            Action action = () => ((ISender)null).AddStatisticsEmittedHandler((sender, s) => { });
+            action.Should().Throw<ArgumentNullException>();
+        }
+        
+        [Fact(DisplayName = "Throws argument null exception for null event handler")]
+        public void SenderAddStatisticsEmittedHandlerSadPath2()
+        {
+            var sender = new KafkaSender("NAME", "TOPIC", 1, "SERVERS");
+            Action action = () => sender.AddStatisticsEmittedHandler(null);
+            action.Should().Throw<ArgumentNullException>();
+        }
+        
+        [Fact(DisplayName = "Throws argument exception for non-KafkaSender")]
+        public void SenderAddStatisticsEmittedHandlerSadPath3()
+        {
+            Action action = () => new Mock<ISender>().Object.AddStatisticsEmittedHandler((sender, s) => { });
+            action.Should().Throw<ArgumentException>();
+        }
+        
+        [Fact(DisplayName = "Adds event handler to given KafkaSender")]
+        public void SenderAddStatisticsEmittedHandlerHappyPath()
+        {
+            var sender = new KafkaSender("NAME", "TOPIC", 1, "SERVERS");
+            var statsData = "STATS!";
+            var callCount = 0;
+
+            void Handler(object s, string stats)
+            {
+                s.Should().BeSameAs(sender);
+                stats.Should().Be(statsData);
+                callCount++;
+            }
+
+            sender.AddStatisticsEmittedHandler(Handler);
+            sender.Unlock().OnStatisticsEmitted(null, statsData);
+            
+            callCount.Should().Be(1, "Event handler should have been called");
+        }
+    }
+}

--- a/docs/Kafka.md
+++ b/docs/Kafka.md
@@ -16,6 +16,8 @@ The first has the following parameters:
   - List of brokers as a CSV list of broker host or host:port.
 - messageTimeoutMs (optional, defaults to 10000)
   - Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
+- statisticsIntervalMs (optional, defaults 0)
+  - The statistics emit interval
 
 The second has the following parameters:
 
@@ -38,6 +40,8 @@ The third has the following parameters:
   - Schema ID for broker to validate message schema against
 - messageTimeoutMs (optional, defaults to 10000)
   - Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
+- statisticsIntervalMs (optional, defaults 0)
+  - The statistics emit interval
 
 The fourth has the following parameters:
 
@@ -145,6 +149,8 @@ The first has the following parameters:
   - Whether the kafka receiver should process messages synchronously.
 - schemaIdRequired
   - Should the receiver expect schema information in the message payload
+- statisticsIntervalMs (optional, defaults 0)
+  - The statistics emit interval
 
 And the second has the following parameters:
 
@@ -235,6 +241,44 @@ Console.ReadLine();
 
 // When finished listening, dispose the receiver.
 receiver.Dispose();
+```
+
+---
+
+## Statistics
+Both the `KafkaReceiver` and `KafkaSender` have a `StatisticsEmitted` event that is invoked when their underlying client emits statistics. 
+This is disabled by default, but can be enabled by setting the `statisticsIntervalMs` parameter during instance construction. The statistics is a JSON formatted string as defined here:
+[https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md](https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md).
+
+```json
+{
+    "RockLib.Messaging": {
+        "Receivers": {
+            "Type": "RockLib.Messaging.Kafka.KafkaReceiver, RockLib.Messaging.Kafka",
+            "Value": {
+                "Name": "commands",
+                "Topic": "test",
+                "GroupId": "test-consumer-group",
+                "BootstrapServers": "localhost:9092",
+                "StatisticsIntervalMs": 60000
+            }
+        }
+    }
+}
+```
+
+```c#
+// MessagingScenarioFactory uses the above JSON configuration to create a KafkaReceiver:
+IReceiver receiver = MessagingScenarioFactory.CreateReceiver("commands");
+
+//StatisticsEmitted event handler
+void OnStatisticsEmitted(object sender, string stats)
+{
+    Console.WriteLine($"Statistics emitted: {stats}");
+}
+
+//convenience extension method for attaching a handler
+receiver.AddStatisticsEmittedHandler(OnStatisticsEmitted);
 ```
 
 ---


### PR DESCRIPTION
## Description
Add an event to the `KafkaReceiver` and `KafkaSender` to relay statistics emitted by their underlying client (i.e. `Producer` and `Consumer`). 

Add convenience extension methods for attaching a handler to the new event since the receiver can be of two different types, namely a concrete `KafkaReceiver/Sender` or a `ConfigReloadingProxy` that wraps the receiver/sender.

## Type of change: New feature
