### PR TITLE
Adding SQS Message ID as a header to SqsReceiverMessage

### DIFF
--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 	
 #### Added
 - Added `.editorconfig` and `Directory.Build.props` files to ensure consistency.
+- Added "SQS.MessageID" as header to SQSReceiverMessages when the not attempting to unpack as an SNS message
 
 #### Changed
 - Supported targets: net6.0, netcoreapp3.1, and net48.

--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 	
 #### Added
 - Added `.editorconfig` and `Directory.Build.props` files to ensure consistency.
-- Added "SQS.MessageID" as header to SQSReceiverMessages when the not attempting to unpack as an SNS message
+- Added "SQS.MessageID" as header to SQSReceiverMessages when not attempting to unpack as an SNS message
 
 #### Changed
 - Supported targets: net6.0, netcoreapp3.1, and net48.

--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 	
 #### Added
 - Added `.editorconfig` and `Directory.Build.props` files to ensure consistency.
-- Added "SQS.MessageID" as header to SQSReceiverMessages when not attempting to unpack as an SNS message
+- Added "SQS.MessageID" as header to SQSReceiverMessages when not attempting to unpack as a SNS message.
 
 #### Changed
 - Supported targets: net6.0, netcoreapp3.1, and net48.

--- a/RockLib.Messaging.SQS/SQSReceiverMessage.cs
+++ b/RockLib.Messaging.SQS/SQSReceiverMessage.cs
@@ -44,7 +44,6 @@ namespace RockLib.Messaging.SQS
         /// <inheritdoc />
         protected override void InitializeHeaders(IDictionary<string, object> headers)
         {
-            
             if (TryGetSNSMessage(Message.Body, _unpackSns, out var snsMessage))
             {
                 headers["TopicARN"] = snsMessage.TopicARN;

--- a/RockLib.Messaging.SQS/SQSReceiverMessage.cs
+++ b/RockLib.Messaging.SQS/SQSReceiverMessage.cs
@@ -44,6 +44,7 @@ namespace RockLib.Messaging.SQS
         /// <inheritdoc />
         protected override void InitializeHeaders(IDictionary<string, object> headers)
         {
+            
             if (TryGetSNSMessage(Message.Body, _unpackSns, out var snsMessage))
             {
                 headers["TopicARN"] = snsMessage.TopicARN;
@@ -53,6 +54,7 @@ namespace RockLib.Messaging.SQS
             }
             else
             {
+                headers["SQS.MessageID"] = Message.MessageId;
                 foreach (var attribute in Message.Attributes)
                     headers[$"SQS.{attribute.Key}"] = attribute.Value;
 

--- a/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
+++ b/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
@@ -453,9 +453,7 @@ namespace RockLib.Messaging.SQS.Tests
             };
 
             var sqsReceiverMessage = new SQSReceiverMessage(message, c => Task.FromResult(0), c => Task.FromResult(0), unpackSNS: true);
-
-
-            //var messageId = 
+ 
             Assert.Throws<KeyNotFoundException>(() => sqsReceiverMessage.Headers.GetValue<string>("SQS.MessageID"));
 
             sqsReceiverMessage.Dispose();

--- a/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
+++ b/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
-using System;
 
 namespace RockLib.Messaging.SQS.Tests
 {
@@ -414,7 +413,7 @@ namespace RockLib.Messaging.SQS.Tests
         }
 
         [Fact]
-        public void SQSReceiverMessageHasSQSMessageIDSetCorrectly()
+        public static void SQSReceiverMessageHasSQSMessageIDSetCorrectly()
         {
             var message = new Message
             {
@@ -427,10 +426,12 @@ namespace RockLib.Messaging.SQS.Tests
             var messageId = sqsReceiverMessage.Headers.GetValue<string>("SQS.MessageID");
 
             messageId.Should().NotBeNull();
+
+            sqsReceiverMessage.Dispose();
         }
 
         [Fact]
-        public void SQSReceiverMessageDoesNotHaveSQSMessageIDHeaderWhenSNS()
+        public static void SQSReceiverMessageDoesNotHaveSQSMessageIDHeaderWhenSNS()
         {
 
             var snsMessage = @"{
@@ -456,6 +457,8 @@ namespace RockLib.Messaging.SQS.Tests
 
             //var messageId = 
             Assert.Throws<KeyNotFoundException>(() => sqsReceiverMessage.Headers.GetValue<string>("SQS.MessageID"));
+
+            sqsReceiverMessage.Dispose();
 
         }
 

--- a/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
+++ b/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
@@ -358,20 +358,20 @@ namespace RockLib.Messaging.SQS.Tests
         public static void SQSReceiverMessageWithUnpackSNSTrueCorrectlyUnpacksSNSMessage()
         {
             var snsMessage = @"{
-  ""Type"" : ""Notification"",
-  ""MessageId"" : ""f5129dcc-0bb0-5e18-9431-c95b6a9b32d9"",
-  ""TopicArn"" : ""arn:PutARealARNHere"",
-  ""Message"" : ""This is a better test message"",
-  ""Timestamp"" : ""2018-12-21T21:45:15.114Z"",
-  ""SignatureVersion"" : ""1"",
-  ""Signature"" : ""SomeSignatureValue"",
-  ""SigningCertURL"" : ""SomeUrl"",
-  ""UnsubscribeURL"" : ""SomeOtherUrl"",
-  ""MessageAttributes"" : {
-    ""core_internal_id"" : {""Type"":""String"",""Value"":""18c4ef1f-62d1-4bd9-aba0-f008a0ac481d""},
-    ""core_originating_system"" : {""Type"":""String"",""Value"":""SNS""}
-  }
-}";
+              ""Type"" : ""Notification"",
+              ""MessageId"" : ""f5129dcc-0bb0-5e18-9431-c95b6a9b32d9"",
+              ""TopicArn"" : ""arn:PutARealARNHere"",
+              ""Message"" : ""This is a better test message"",
+              ""Timestamp"" : ""2018-12-21T21:45:15.114Z"",
+              ""SignatureVersion"" : ""1"",
+              ""Signature"" : ""SomeSignatureValue"",
+              ""SigningCertURL"" : ""SomeUrl"",
+              ""UnsubscribeURL"" : ""SomeOtherUrl"",
+              ""MessageAttributes"" : {
+                ""core_internal_id"" : {""Type"":""String"",""Value"":""18c4ef1f-62d1-4bd9-aba0-f008a0ac481d""},
+                ""core_originating_system"" : {""Type"":""String"",""Value"":""SNS""}
+              }
+            }";
 
             var message = new Message
             {
@@ -390,16 +390,16 @@ namespace RockLib.Messaging.SQS.Tests
         public static void SQSReceiverMessageWithUnpackSNSTrueCorrectlyUnpacksSNSMessageWithNoMessageAttributes()
         {
             var snsMessage = @"{
-  ""Type"" : ""Notification"",
-  ""MessageId"" : ""f5129dcc-0bb0-5e18-9431-c95b6a9b32d9"",
-  ""TopicArn"" : ""arn:PutARealARNHere"",
-  ""Message"" : ""This is a better test message"",
-  ""Timestamp"" : ""2018-12-21T21:45:15.114Z"",
-  ""SignatureVersion"" : ""1"",
-  ""Signature"" : ""SomeSignatureValue"",
-  ""SigningCertURL"" : ""SomeUrl"",
-  ""UnsubscribeURL"" : ""SomeOtherUrl""
-}";
+              ""Type"" : ""Notification"",
+              ""MessageId"" : ""f5129dcc-0bb0-5e18-9431-c95b6a9b32d9"",
+              ""TopicArn"" : ""arn:PutARealARNHere"",
+              ""Message"" : ""This is a better test message"",
+              ""Timestamp"" : ""2018-12-21T21:45:15.114Z"",
+              ""SignatureVersion"" : ""1"",
+              ""Signature"" : ""SomeSignatureValue"",
+              ""SigningCertURL"" : ""SomeUrl"",
+              ""UnsubscribeURL"" : ""SomeOtherUrl""
+            }";
 
             var message = new Message
             {
@@ -434,16 +434,16 @@ namespace RockLib.Messaging.SQS.Tests
         {
 
             var snsMessage = @"{
-  ""Type"" : ""Notification"",
-  ""MessageId"" : ""f5129dcc-0bb0-5e18-9431-c95b6a9b32d9"",
-  ""TopicArn"" : ""arn:PutARealARNHere"",
-  ""Message"" : ""This is a better test message"",
-  ""Timestamp"" : ""2018-12-21T21:45:15.114Z"",
-  ""SignatureVersion"" : ""1"",
-  ""Signature"" : ""SomeSignatureValue"",
-  ""SigningCertURL"" : ""SomeUrl"",
-  ""UnsubscribeURL"" : ""SomeOtherUrl""
-}";
+              ""Type"" : ""Notification"",
+              ""MessageId"" : ""f5129dcc-0bb0-5e18-9431-c95b6a9b32d9"",
+              ""TopicArn"" : ""arn:PutARealARNHere"",
+              ""Message"" : ""This is a better test message"",
+              ""Timestamp"" : ""2018-12-21T21:45:15.114Z"",
+              ""SignatureVersion"" : ""1"",
+              ""Signature"" : ""SomeSignatureValue"",
+              ""SigningCertURL"" : ""SomeUrl"",
+              ""UnsubscribeURL"" : ""SomeOtherUrl""
+            }";
 
             var message = new Message
             {

--- a/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
+++ b/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
@@ -421,13 +421,12 @@ namespace RockLib.Messaging.SQS.Tests
                 Body = @"{""TestMessageItem"":""ThisIsAFakeItem""}"
             };
 
-            var sqsReceiverMessage = new SQSReceiverMessage(message, c => Task.FromResult(0), c => Task.FromResult(0), unpackSNS: false);
+            using (var sqsReceiverMessage = new SQSReceiverMessage(message, c => Task.FromResult(0), c => Task.FromResult(0), unpackSNS: false))
+            {
+                var messageId = sqsReceiverMessage.Headers.GetValue<string>("SQS.MessageID");
 
-            var messageId = sqsReceiverMessage.Headers.GetValue<string>("SQS.MessageID");
-
-            messageId.Should().NotBeNull();
-
-            sqsReceiverMessage.Dispose();
+                messageId.Should().NotBeNull();
+            }
         }
 
         [Fact]
@@ -452,12 +451,11 @@ namespace RockLib.Messaging.SQS.Tests
                 Body = snsMessage
             };
 
-            var sqsReceiverMessage = new SQSReceiverMessage(message, c => Task.FromResult(0), c => Task.FromResult(0), unpackSNS: true);
+            using (var sqsReceiverMessage = new SQSReceiverMessage(message, c => Task.FromResult(0), c => Task.FromResult(0), unpackSNS: true))
+            {
+                Assert.Throws<KeyNotFoundException>(() => sqsReceiverMessage.Headers.GetValue<string>("SQS.MessageID"));
+            }
  
-            Assert.Throws<KeyNotFoundException>(() => sqsReceiverMessage.Headers.GetValue<string>("SQS.MessageID"));
-
-            sqsReceiverMessage.Dispose();
-
         }
 
         private static void SetupDeleteMessageAsync(Mock<IAmazonSQS> mockSqs, HttpStatusCode httpStatusCode = HttpStatusCode.OK)


### PR DESCRIPTION
## Description
Adding the SQS Message ID as a header in the SqsReceiverMessage.
Currently the ID of the SQS message being read is not accessible.


## Type of change: 
3. New feature (non-breaking change that adds functionality)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
