### PR TITLE
Bump AWSSDK.SQS version to fix a recent AWSSDK issue

### DIFF
--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.1 - 2022-03-21
+
+#### Fixed
+- Updated AWSSDK.SQS dependency version due to recent [bug](https://github.com/aws/aws-sdk-net/issues/1992)
+
 ## 3.0.0 - 2022-03-11
 	
 #### Added

--- a/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
+++ b/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
@@ -34,7 +34,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AWSSDK.SQS" Version="3.7.2.29" />
+		<PackageReference Include="AWSSDK.SQS" Version="3.7.2.35" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="RockLib.Messaging" Version="3.0.0" />
 	</ItemGroup>


### PR DESCRIPTION
## Description
Recently there was a breaking change introduced to AWSSDK.Core/AWSDK.SQS - https://github.com/aws/aws-sdk-net/issues/1992.  This bumps our reference to AWSSDK.SQS to resolve the issue when paired with AWSSDK.Core.

## Type of change: <!-- Choose the highest number that applies -->
This is a bug fix for pairing with certain versions of AWSSDK.Core.

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
