### PR TITLE
Library Updates and Modernization

### DIFF
--- a/RockLib.Messaging.Http/.editorconfig
+++ b/RockLib.Messaging.Http/.editorconfig
@@ -1,0 +1,69 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.cs]
+# Styling
+indent_style = space
+indent_size = 4
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = false
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = methods, control_blocks, types, properties, lambdas, accessors, object_collection_array_initializers
+csharp_new_line_between_query_expression_clauses = true
+csharp_prefer_braces = false:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_preferred_modifier_order = public,private,internal,protected,static,readonly,async,override,sealed:suggestion
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+dotnet_sort_system_directives_first = false
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = false:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+
+# Analyzer Configuration
+# These are rules we want to either ignore or have set as suggestion or info
+
+# CA1014: Mark assemblies with CLSCompliant
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# CA1725: Parameter names should match base declaration
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA2227: Collection properties should be read only
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = suggestion

--- a/RockLib.Messaging.Http/CHANGELOG.md
+++ b/RockLib.Messaging.Http/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - Supported targets: net6.0, netcoreapp3.1, and net48.
 - As the package now uses nullable reference types, some method parameters now specify if they can accept nullable values.
-- The field `url` was updated to Uri type from string in the following places:
+- The field `url` now accepts the Uri type in `HttpClientSender` and `HttpListenerReceiver`.
+  - This is now the prefered way to use these methods.
+  - In the future, versions of these method accepting string urls will be marked obsolete.
 
 ## 1.0.8 - 2021-08-12
 

--- a/RockLib.Messaging.Http/CHANGELOG.md
+++ b/RockLib.Messaging.Http/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+#### Added
+- Added `.editorconfig` and `Directory.Build.props` files to ensure consistency.
+
+#### Changed
+- Supported targets: net6.0, netcoreapp3.1, and net48.
+- As the package now uses nullable reference types, some method parameters now specify if they can accept nullable values.
+- The field `url` was updated to Uri type from string in the following places:
+
 ## 1.0.8 - 2021-08-12
 
 #### Changed

--- a/RockLib.Messaging.Http/DefaultHttpResponseGenerator.cs
+++ b/RockLib.Messaging.Http/DefaultHttpResponseGenerator.cs
@@ -27,17 +27,23 @@
         /// <summary>
         /// Gets the response to be returned from calls to <see cref="GetAcknowledgeResponse"/>.
         /// </summary>
+#pragma warning disable CA1721 // Property names should not match get methods
         public HttpResponse AcknowledgeResponse { get; }
+#pragma warning restore CA1721 // Property names should not match get methods
 
         /// <summary>
         /// Gets the response to be returned from calls to <see cref="GetRollbackResponse"/>.
         /// </summary>
+#pragma warning disable CA1721 // Property names should not match get methods
         public HttpResponse RollbackResponse { get; }
+#pragma warning restore CA1721 // Property names should not match get methods
 
         /// <summary>
         /// Gets the response to be returned from calls to <see cref="GetRejectResponse"/>.
         /// </summary>
+#pragma warning disable CA1721 // Property names should not match get methods
         public HttpResponse RejectResponse { get; }
+#pragma warning restore CA1721 // Property names should not match get methods
 
         /// <summary>
         /// Returns <see cref="AcknowledgeResponse"/>.

--- a/RockLib.Messaging.Http/Directory.Build.props
+++ b/RockLib.Messaging.Http/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+	</PropertyGroup>
+	<PropertyGroup>
+		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<Authors>Rocket Mortgage</Authors>
+		<Copyright>Copyright 2022 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+		<NoWarn>NU1603,NU1701</NoWarn>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/RockLib.Messaging.Http/HttpClientSender.cs
+++ b/RockLib.Messaging.Http/HttpClientSender.cs
@@ -134,10 +134,11 @@ namespace RockLib.Messaging.Http
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public async Task SendAsync(SenderMessage message, CancellationToken cancellationToken)
         {
-            if(message is null)
+            if (message is null)
             {
                 throw new ArgumentNullException(nameof(message));
             }
+
             if (message.OriginatingSystem is null)
             {
                 message.OriginatingSystem = "HTTP";

--- a/RockLib.Messaging.Http/HttpClientSender.cs
+++ b/RockLib.Messaging.Http/HttpClientSender.cs
@@ -13,9 +13,7 @@ namespace RockLib.Messaging.Http
     /// An implementation of <see cref="ISender" /> that sends messages with an
     /// <see cref="HttpClient"/>.
     /// </summary>
-#pragma warning disable CS1069
     public class HttpClientSender : ISender
-#pragma warning restore CS1069
     {
         private readonly HttpContentHeaders _defaultContentHeaders = new ByteArrayContent(Array.Empty<byte>()).Headers;
         private readonly HttpRequestHeaders _defaultRequestHeaders = new HttpRequestMessage().Headers;

--- a/RockLib.Messaging.Http/HttpListenerReceiver.cs
+++ b/RockLib.Messaging.Http/HttpListenerReceiver.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 
@@ -30,8 +29,6 @@ namespace RockLib.Messaging.Http
         private readonly IReadOnlyCollection<string> _pathTokens;
 
         private bool _disposed;
-
-        
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpListenerReceiver"/> class.

--- a/RockLib.Messaging.Http/HttpListenerReceiverMessage.cs
+++ b/RockLib.Messaging.Http/HttpListenerReceiverMessage.cs
@@ -62,8 +62,10 @@ namespace RockLib.Messaging.Http
         {
             Context.Response.StatusCode = response.StatusCode;
 
-            if (response.StatusDescription != null)
+            if (response.StatusDescription is not null)
+            {
                 Context.Response.StatusDescription = response.StatusDescription;
+            }
 
             switch (response.Content)
             {
@@ -100,6 +102,7 @@ namespace RockLib.Messaging.Http
             {
                 throw new ArgumentNullException(nameof(headers));
             }
+
             foreach (var key in Context.Request.Headers.AllKeys)
             {
                 headers.Add(key!, Context.Request.Headers[key]!);

--- a/RockLib.Messaging.Http/HttpResponse.cs
+++ b/RockLib.Messaging.Http/HttpResponse.cs
@@ -14,8 +14,8 @@ namespace RockLib.Messaging.Http
         /// <param name="statusCode">The http status code of the response.</param>
         /// <param name="statusDescription">The http status description of the response.</param>
         /// <param name="content">The string content of the response.</param>
-        public HttpResponse(int statusCode, string content = null, string statusDescription = null)
-            : this(statusCode, statusDescription, (object)content)
+        public HttpResponse(int statusCode, string? content = null, string? statusDescription = null)
+            : this(statusCode, statusDescription, (object)content!)
         {
         }
 
@@ -25,12 +25,12 @@ namespace RockLib.Messaging.Http
         /// <param name="statusCode">The http status code of the response.</param>
         /// <param name="statusDescription">The http status description of the response.</param>
         /// <param name="content">The binary content of the response.</param>
-        public HttpResponse(int statusCode, byte[] content, string statusDescription = null)
-            : this(statusCode, statusDescription, (object)content)
+        public HttpResponse(int statusCode, byte[] content, string? statusDescription = null)
+            : this(statusCode, statusDescription, content)
         {
         }
 
-        private HttpResponse(int statusCode, string statusDescription, object content)
+        private HttpResponse(int statusCode, string? statusDescription, object? content)
         {
             if (statusCode < 100 || statusCode > 999)
                 throw new ArgumentException("statusCode cannot be less than 100 or greater than 999.", nameof(statusCode));
@@ -47,12 +47,12 @@ namespace RockLib.Messaging.Http
         /// <summary>
         /// Gets the status description of the response.
         /// </summary>
-        public string StatusDescription { get; }
+        public string? StatusDescription { get; }
 
         /// <summary>
         /// Gets the content of the response.
         /// </summary>
-        public object Content { get; }
+        public object? Content { get; }
 
         /// <summary>
         /// Gets a dictionary representing the headers of the response.

--- a/RockLib.Messaging.Http/HttpResponse.cs
+++ b/RockLib.Messaging.Http/HttpResponse.cs
@@ -33,7 +33,9 @@ namespace RockLib.Messaging.Http
         private HttpResponse(int statusCode, string? statusDescription, object? content)
         {
             if (statusCode < 100 || statusCode > 999)
+            {
                 throw new ArgumentException("statusCode cannot be less than 100 or greater than 999.", nameof(statusCode));
+            }
             StatusCode = statusCode;
             StatusDescription = statusDescription;
             Content = content;

--- a/RockLib.Messaging.Http/RequiredHttpRequestHeaders.cs
+++ b/RockLib.Messaging.Http/RequiredHttpRequestHeaders.cs
@@ -64,15 +64,10 @@ namespace RockLib.Messaging.Http
                 return true;
             }
 
-            try
+            var validContentType = MediaTypeHeaderValue.TryParse(requestContentType, out var contentType);
+            if (validContentType)
             {
-                var contentType = MediaTypeHeaderValue.Parse(requestContentType);
-                return _contentTypeMediaTypes.Any(mediaType => contentType.MediaType == mediaType);
-            }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch
-#pragma warning restore CA1031 // Do not catch general exception types
-            {
+                return _contentTypeMediaTypes.Any(mediaType => contentType?.MediaType == mediaType);
             }
 
             return false;
@@ -85,25 +80,18 @@ namespace RockLib.Messaging.Http
                 return true;
             }
 
-            try
+            if (requestAcceptTypes is null)
             {
-                if (requestAcceptTypes is null)
-                {
-                    throw new ArgumentNullException(nameof(requestAcceptTypes));
-                }
-                foreach (var requestAcceptType in requestAcceptTypes)
-                {
-                    var accept = MediaTypeWithQualityHeaderValue.Parse(requestAcceptType);
-                    if (_acceptMediaTypes.Any(mediaType => accept.MediaType == mediaType))
-                    {
-                        return true;
-                    }
-                }
+                throw new ArgumentNullException(nameof(requestAcceptTypes));
             }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch
-#pragma warning restore CA1031 // Do not catch general exception types
+
+            foreach (var requestAcceptType in requestAcceptTypes)
             {
+                var validAccept = MediaTypeWithQualityHeaderValue.TryParse(requestAcceptType, out var accept);
+                if (_acceptMediaTypes.Any(mediaType => accept?.MediaType == mediaType))
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/RockLib.Messaging.Http/RockLib.Messaging.Http.csproj
+++ b/RockLib.Messaging.Http/RockLib.Messaging.Http.csproj
@@ -39,6 +39,10 @@
     <PackageReference Include="RockLib.Messaging" Version="3.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net48'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
   <Import Project="..\RockLib.Messaging.HttpUtils\RockLib.Messaging.HttpUtils.projitems" Label="Shared" />
 
 </Project>

--- a/RockLib.Messaging.Http/RockLib.Messaging.Http.csproj
+++ b/RockLib.Messaging.Http/RockLib.Messaging.Http.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.0;net451;net462</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <PackageId>RockLib.Messaging.Http</PackageId>
     <PackageVersion>1.0.8</PackageVersion>
     <Authors>RockLib</Authors>
@@ -14,7 +10,6 @@
     <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageIcon>icon.png</PackageIcon>
-    <Copyright>Copyright 2018-2021 (c) Rocket Mortgage. All rights reserved.</Copyright>
     <PackageTags>rocklib messaging http</PackageTags>
     <Version>1.0.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -32,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RockLib.Messaging" Version="2.5.3" />
+    <PackageReference Include="RockLib.Messaging" Version="3.0.0" />
   </ItemGroup>
 
   <Import Project="..\RockLib.Messaging.HttpUtils\RockLib.Messaging.HttpUtils.projitems" Label="Shared" />

--- a/RockLib.Messaging.Http/RockLib.Messaging.Http.sln
+++ b/RockLib.Messaging.Http/RockLib.Messaging.Http.sln
@@ -1,13 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2047
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Messaging.Http", "RockLib.Messaging.Http.csproj", "{C74A231E-DDE2-413F-BBF2-673AE2DB9B51}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Messaging.Http.Tests", "..\Tests\RockLib.Messaging.Http.Tests\RockLib.Messaging.Http.Tests.csproj", "{BA8E64C8-2F6F-468D-91CD-225D0357A43E}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\RockLib.Messaging.HttpUtils\RockLib.Messaging.HttpUtils.projitems*{c74a231e-dde2-413f-bbf2-673ae2db9b51}*SharedItemsImports = 5
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/RockLib.Messaging.Http/appveyor.yml
+++ b/RockLib.Messaging.Http/appveyor.yml
@@ -1,5 +1,5 @@
 version: 'RockLib.Messaging.Http.{build}.0.0-ci'
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 only_commits:
   files:

--- a/RockLib.Messaging.HttpUtils/HttpUtils.cs
+++ b/RockLib.Messaging.HttpUtils/HttpUtils.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
 
@@ -71,8 +73,11 @@ namespace RockLib.Messaging
         private static IEnumerable<string> SplitByComma(string headerValue)
         {
             string value;
-
-            if (!headerValue.Contains(","))
+#if NET48
+            if (!headerValue.Contains(','))
+#else
+            if (!headerValue.Contains(',', StringComparison.InvariantCultureIgnoreCase))
+#endif
             {
                 value = headerValue.Trim();
                 if (value.Length > 0)

--- a/Tests/RockLib.Messaging.Http.Tests/.editorconfig
+++ b/Tests/RockLib.Messaging.Http.Tests/.editorconfig
@@ -1,0 +1,69 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.cs]
+# Styling
+indent_style = space
+indent_size = 4
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = false
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = methods, control_blocks, types, properties, lambdas, accessors, object_collection_array_initializers
+csharp_new_line_between_query_expression_clauses = true
+csharp_prefer_braces = false:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_preferred_modifier_order = public,private,internal,protected,static,readonly,async,override,sealed:suggestion
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+dotnet_sort_system_directives_first = false
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = false:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+
+# Analyzer Configuration
+# These are rules we want to either ignore or have set as suggestion or info
+
+# CA1014: Mark assemblies with CLSCompliant
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# CA1725: Parameter names should match base declaration
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA2227: Collection properties should be read only
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = suggestion

--- a/Tests/RockLib.Messaging.Http.Tests/AssemblySettings.cs
+++ b/Tests/RockLib.Messaging.Http.Tests/AssemblySettings.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/Tests/RockLib.Messaging.Http.Tests/Directory.Build.props
+++ b/Tests/RockLib.Messaging.Http.Tests/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+	</PropertyGroup>
+	<PropertyGroup>
+		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<Authors>Rocket Mortgage</Authors>
+		<Copyright>Copyright 2022 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+		<NoWarn>NU1603,NU1701</NoWarn>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/Tests/RockLib.Messaging.Http.Tests/RockLib.Messaging.Http.Tests.csproj
+++ b/Tests/RockLib.Messaging.Http.Tests/RockLib.Messaging.Http.Tests.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net462;</TargetFrameworks>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description

Updated target frameworks to net6.0, netcoreapp3.1, and net48.

Added .editorconfig and Directory.Build.props for consistency.

Updated `HttpClientSender` and `HttpListenerReceiver` to use Uri type for url field.  Noted in changelog that the methods that currently accept string urls will be marked obsolete in the future and that the Uri type is the preferred method to use.

## Type of change: 4

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
