### PR TITLE
144 cloud events target frameworks

### DIFF
--- a/RockLib.Messaging.CloudEvents/.editorconfig
+++ b/RockLib.Messaging.CloudEvents/.editorconfig
@@ -1,0 +1,69 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.cs]
+# Styling
+indent_style = space
+indent_size = 4
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = false
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = methods, control_blocks, types, properties, lambdas, accessors, object_collection_array_initializers
+csharp_new_line_between_query_expression_clauses = true
+csharp_prefer_braces = false:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_preferred_modifier_order = public,private,internal,protected,static,readonly,async,override,sealed:suggestion
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+dotnet_sort_system_directives_first = false
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = false:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+
+# Analyzer Configuration
+# These are rules we want to either ignore or have set as suggestion or info
+
+# CA1014: Mark assemblies with CLSCompliant
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# CA1725: Parameter names should match base declaration
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA2227: Collection properties should be read only
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = suggestion

--- a/RockLib.Messaging.CloudEvents/CHANGELOG.md
+++ b/RockLib.Messaging.CloudEvents/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - Supported targets: net6.0, netcoreapp3.1, and net48.
 - As the package now uses nullable reference types, some method parameters now specify if they can accept nullable values.
-- The field `url` now accepts the Uri type in `CloudEvent.ToHttpRequestMessage`.
+- The field `url` is now a Uri type in `CloudEvent.ToHttpRequestMessage`.
 
 ## 1.0.2 - 2021-08-12
 

--- a/RockLib.Messaging.CloudEvents/CHANGELOG.md
+++ b/RockLib.Messaging.CloudEvents/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+#### Added
+- Added `.editorconfig` and `Directory.Build.props` files to ensure consistency.
+
+#### Changed
+- Supported targets: net6.0, netcoreapp3.1, and net48.
+- As the package now uses nullable reference types, some method parameters now specify if they can accept nullable values.
+- The field `url` now accepts the Uri type in `CloudEvent.ToHttpRequestMessage`.
+
 ## 1.0.2 - 2021-08-12
 
 #### Changed

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -827,7 +827,7 @@ namespace RockLib.Messaging.CloudEvents
 
         private static bool IsStructuredMode(IReceiverMessage receiverMessage) =>
             receiverMessage.Headers.TryGetValue(StructuredModeContentTypeHeader, out string? contentType)
-            && contentType is not null && contentType.StartsWith(StructuredModeMediaTypePrefix);
+            && contentType is not null && contentType.StartsWith(StructuredModeMediaTypePrefix, StringComparison.InvariantCulture);
 
     }
 }

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -133,7 +133,7 @@ namespace RockLib.Messaging.CloudEvents
         /// </param>
         public CloudEvent(string jsonFormattedCloudEvent)
         {
-            if (string.IsNullOrEmpty(jsonFormattedCloudEvent))
+            if (string.IsNullOrWhiteSpace(jsonFormattedCloudEvent))
             {
                 throw new ArgumentNullException(nameof(jsonFormattedCloudEvent));
             }
@@ -199,7 +199,7 @@ namespace RockLib.Messaging.CloudEvents
             }
             set
             {
-                if (string.IsNullOrEmpty(value))
+                if (string.IsNullOrWhiteSpace(value))
                 {
                     throw new ArgumentNullException(nameof(value));
                 }
@@ -303,7 +303,7 @@ namespace RockLib.Messaging.CloudEvents
                     return _contentType;
                 }
 
-                if (string.IsNullOrEmpty(DataContentType))
+                if (string.IsNullOrWhiteSpace(DataContentType))
                 {
                     return null;
                 }
@@ -750,7 +750,7 @@ namespace RockLib.Messaging.CloudEvents
                 throw new CloudEventValidationException("Source cannot be null.");
             }
 
-            if (string.IsNullOrEmpty(Type))
+            if (string.IsNullOrWhiteSpace(Type))
             {
                 throw new CloudEventValidationException("Type cannot be null or empty.");
             }

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -584,7 +584,7 @@ namespace RockLib.Messaging.CloudEvents
         /// to render in Binary Mode.
         /// </param>
         /// <returns>The mapped <see cref="HttpRequestMessage"/>.</returns>
-        public HttpRequestMessage ToHttpRequestMessage(string? requestUri = null, bool structuredMode = false) =>
+        public HttpRequestMessage ToHttpRequestMessage(Uri? requestUri = null, bool structuredMode = false) =>
             ToHttpRequestMessage(HttpMethod.Get, requestUri, structuredMode);
 
         /// <summary>
@@ -597,7 +597,7 @@ namespace RockLib.Messaging.CloudEvents
         /// to render in Binary Mode.
         /// </param>
         /// <returns>The mapped <see cref="HttpRequestMessage"/>.</returns>
-        public HttpRequestMessage ToHttpRequestMessage(HttpMethod method, string? requestUri = null, bool structuredMode = false)
+        public HttpRequestMessage ToHttpRequestMessage(HttpMethod method, Uri? requestUri = null, bool structuredMode = false)
         {
             if (method is null)
                 throw new ArgumentNullException(nameof(method));

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -225,7 +225,7 @@ namespace RockLib.Messaging.CloudEvents
         /// REQUIRED. The version of the CloudEvents specification which the event uses. This
         /// enables the interpretation of the context. Always returns '1.0'.
         /// </summary>
-        public string SpecVersion => _specVersion1_0;
+        public static string SpecVersion => _specVersion1_0;
 
         /// <summary>
         /// REQUIRED. This attribute contains a value describing the type of event related to the
@@ -521,7 +521,7 @@ namespace RockLib.Messaging.CloudEvents
                 else
                     senderMessage = new SenderMessage("");
 
-                senderMessage.Headers[ProtocolBinding.GetHeaderName(SpecVersionAttribute)] = SpecVersion;
+                senderMessage.Headers[ProtocolBinding.GetHeaderName(SpecVersionAttribute)] = CloudEvent.SpecVersion;
 
                 foreach (var attribute in Attributes)
                     senderMessage.Headers[ProtocolBinding.GetHeaderName(attribute.Key)] = attribute.Value;

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -710,7 +710,7 @@ namespace RockLib.Messaging.CloudEvents
         /// </returns>
         protected static bool ContainsHeader<T>(SenderMessage senderMessage, string headerName)
         {
-            if (senderMessage.Headers.TryGetValue(headerName, out var objectValue))
+            if (senderMessage is not null && senderMessage.Headers.TryGetValue(headerName, out var objectValue))
             {
                 switch (objectValue)
                 {
@@ -765,7 +765,7 @@ namespace RockLib.Messaging.CloudEvents
         /// </returns>
         protected static bool TryGetHeaderValue<T>(SenderMessage senderMessage, string headerName, out T? value)
         {
-            if (senderMessage.Headers.TryGetValue(headerName, out var objectValue))
+            if (senderMessage is not null && senderMessage.Headers.TryGetValue(headerName, out var objectValue))
             {
                 switch (objectValue)
                 {

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text.Json;
 using static RockLib.Messaging.HttpUtils;
 
 namespace RockLib.Messaging.CloudEvents

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -849,14 +849,7 @@ namespace RockLib.Messaging.CloudEvents
                 var converter = TypeDescriptor.GetConverter(typeof(T));
                 if (converter.CanConvertFrom(objectValue.GetType()))
                 {
-                    try
-                    {
-                        converter.ConvertFrom(objectValue);
-                        return true;
-                    }
-                    catch (Exception ex) when (ex is NotSupportedException)
-                    {
-                    }
+                    return true;
                 }
 
                 converter = TypeDescriptor.GetConverter(objectValue);

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using static RockLib.Messaging.HttpUtils;
 
 namespace RockLib.Messaging.CloudEvents
@@ -410,8 +411,14 @@ namespace RockLib.Messaging.CloudEvents
             else if (_data is string stringData)
             {
                 JToken dataToken;
-                try { dataToken = JToken.Parse(stringData); }
-                catch { dataToken = new JValue(stringData); }
+                try
+                {
+                    dataToken = JToken.Parse(stringData);
+                }
+                catch (Exception ex) when (ex is JsonReaderException)
+                {
+                    dataToken = new JValue(stringData);
+                }
                 jobject["data"] = dataToken;
             }
 
@@ -718,7 +725,9 @@ namespace RockLib.Messaging.CloudEvents
                         converter.ConvertFrom(objectValue);
                         return true;
                     }
-                    catch { }
+                    catch (Exception ex) when (ex is NotSupportedException)
+                    {
+                    }
 
                 converter = TypeDescriptor.GetConverter(objectValue);
                 if (converter.CanConvertTo(typeof(T)))
@@ -727,7 +736,9 @@ namespace RockLib.Messaging.CloudEvents
                         converter.ConvertTo(objectValue, typeof(T));
                         return true;
                     }
-                    catch { }
+                    catch (Exception ex) when (ex is NotSupportedException)
+                    {
+                    }
             }
 
             return false;
@@ -781,7 +792,7 @@ namespace RockLib.Messaging.CloudEvents
                         value = (T)converter.ConvertFrom(objectValue)!;
                         return true;
                     }
-                    catch
+                    catch (Exception ex) when (ex is NotSupportedException)
                     {
                     }
                 }
@@ -794,7 +805,7 @@ namespace RockLib.Messaging.CloudEvents
                         value = (T)converter.ConvertTo(objectValue, typeof(T))!;
                         return true;
                     }
-                    catch
+                    catch (Exception ex) when (ex is NotSupportedException)
                     {
                     }
                 }

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -200,7 +200,7 @@ namespace RockLib.Messaging.CloudEvents
         /// encoded in the URI is defined by the event producer.
         /// <para>Must be a valid relative or absolute URI.</para>
         /// </summary>
-        public string Source
+        public string? Source
         {
             get => Attributes.TryGetValue(SourceAttribute, out var value) && value is string source
                 ? source
@@ -229,7 +229,7 @@ namespace RockLib.Messaging.CloudEvents
         /// enforcement, etc. The format of this is producer defined and might include information
         /// such as the version of the type.
         /// </summary>
-        public string Type
+        public string? Type
         {
             get => Attributes.TryGetValue(TypeAttribute, out var value) && value is string type
                 ? type
@@ -247,7 +247,7 @@ namespace RockLib.Messaging.CloudEvents
         /// Content type of data value.
         /// <para>Must be a valid Content-Type value according to RFC 2616.</para>
         /// </summary>
-        public string DataContentType
+        public string? DataContentType
         {
             get => Attributes.TryGetValue(DataContentTypeAttribute, out var value) && value is string dataContentType
                 ? dataContentType
@@ -270,7 +270,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <summary>
         /// Content type of data value as a <see cref="MediaTypeHeaderValue"/>.
         /// </summary>
-        public MediaTypeHeaderValue ContentType
+        public MediaTypeHeaderValue? ContentType
         {
             get
             {
@@ -288,7 +288,7 @@ namespace RockLib.Messaging.CloudEvents
         /// reflected by a different URI.
         /// <para>Must be a valid relative or absolute URI.</para>
         /// </summary>
-        public string DataSchema
+        public string? DataSchema
         {
             get => Attributes.TryGetValue(DataSchemaAttribute, out var value) && value is string dataSchema
                 ? dataSchema
@@ -317,7 +317,7 @@ namespace RockLib.Messaging.CloudEvents
         /// interested in blobs with names ending with '.jpg' or '.jpeg' and the subject attribute allows
         /// for constructing a simple and efficient string-suffix filter for that subset of events.</para>
         /// </summary>
-        public string Subject
+        public string? Subject
         {
             get => Attributes.TryGetValue(SubjectAttribute, out var value) && value is string subject
                 ? subject
@@ -369,7 +369,7 @@ namespace RockLib.Messaging.CloudEvents
         /// .SetData{TCloudEvent}(TCloudEvent, string)"/> or <see cref="CloudEventExtensions
         /// .SetData{TCloudEvent, T}(TCloudEvent, T, DataSerialization)"/> extension method.</para>
         /// </summary>
-        public string StringData => _data as string;
+        public string? StringData => _data as string;
 
         /// <summary>
         /// Domain-specific information about the occurrence (i.e. the payload) as a byte array.
@@ -378,7 +378,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <para>To set this value, call the <see cref="CloudEventExtensions.SetData{TCloudEvent}(
         /// TCloudEvent, byte[])"/> extension method.</para>
         /// </summary>
-        public byte[] BinaryData => _data as byte[];
+        public byte[]? BinaryData => _data as byte[];
 
         /// <summary>
         /// Converts the cloud event to a string in the
@@ -615,7 +615,7 @@ namespace RockLib.Messaging.CloudEvents
         /// </summary>
         /// <param name="cloudEvent">The <see cref="CloudEvent"/> to convert to a <see cref="SenderMessage"/>.</param>
         public static implicit operator SenderMessage(CloudEvent cloudEvent) =>
-            cloudEvent?.ToSenderMessage();
+            cloudEvent?.ToSenderMessage()!;
 
         /// <summary>
         /// Ensures that the cloud event is valid - throws a <see cref="CloudEventValidationException"/>

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -470,7 +470,7 @@ namespace RockLib.Messaging.CloudEvents
                     Attributes[attribute.Key] = jvalue.Value;
                 else
                     throw new CloudEventValidationException(
-                        $"Invalid value for '{attribute.Key}' member: {attribute.Value.ToString(Formatting.Indented)}");
+                        $"Invalid value for '{attribute.Key}' member: {attribute.Value?.ToString(Formatting.Indented)}");
             }
         }
 

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -578,7 +578,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <summary>
         /// Creates an <see cref="HttpRequestMessage"/> with headers mapped from the attributes of this cloud event.
         /// </summary>
-        /// <param name="requestUri">A string that represents the request <see cref="Uri"/>.</param>
+        /// <param name="requestUri">A Uri that represents the request <see cref="Uri"/>.</param>
         /// <param name="structuredMode">
         /// <see langword="true"/> to render in Structured Mode, otherwise <see langword="false"/>
         /// to render in Binary Mode.
@@ -591,7 +591,7 @@ namespace RockLib.Messaging.CloudEvents
         /// Creates an <see cref="HttpRequestMessage"/> with headers mapped from the attributes of this cloud event.
         /// </summary>
         /// <param name="method">The HTTP method of the request.</param>
-        /// <param name="requestUri">A string that represents the request <see cref="Uri"/>.</param>
+        /// <param name="requestUri">A Uri that represents the request <see cref="Uri"/>.</param>
         /// <param name="structuredMode">
         /// <see langword="true"/> to render in Structured Mode, otherwise <see langword="false"/>
         /// to render in Binary Mode.

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -61,11 +61,11 @@ namespace RockLib.Messaging.CloudEvents
 
         private const string _specVersion1_0 = "1.0";
 
-        private static IProtocolBinding _defaultProtocolBinding;
-        private IProtocolBinding _protocolBinding;
+        private static IProtocolBinding _defaultProtocolBinding = ProtocolBindings.Default;
+        private IProtocolBinding? _protocolBinding;
 
-        private object _data;
-        private MediaTypeHeaderValue _contentType;
+        private object? _data;
+        private MediaTypeHeaderValue? _contentType;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudEvent"/> class.
@@ -106,7 +106,7 @@ namespace RockLib.Messaging.CloudEvents
         /// CloudEvent attributes. If <see langword="null"/>, then <see cref="DefaultProtocolBinding"/>
         /// is used instead.
         /// </param>
-        public CloudEvent(IReceiverMessage receiverMessage, IProtocolBinding protocolBinding = null)
+        public CloudEvent(IReceiverMessage receiverMessage, IProtocolBinding? protocolBinding = null)
         {
             if (receiverMessage is null)
                 throw new ArgumentNullException(nameof(receiverMessage));
@@ -149,7 +149,7 @@ namespace RockLib.Messaging.CloudEvents
         /// </summary>
         public static IProtocolBinding DefaultProtocolBinding
         {
-            get => _defaultProtocolBinding ?? (_defaultProtocolBinding = ProtocolBindings.Default);
+            get => _defaultProtocolBinding;
             set => _defaultProtocolBinding = value ?? throw new ArgumentNullException(nameof(value));
         }
 
@@ -160,7 +160,7 @@ namespace RockLib.Messaging.CloudEvents
         /// </summary>
         public IProtocolBinding ProtocolBinding
         {
-            get => _protocolBinding ?? (_protocolBinding = DefaultProtocolBinding);
+            get => _protocolBinding ?? _defaultProtocolBinding;
             set => _protocolBinding = value ?? throw new ArgumentNullException(nameof(value));
         }
 
@@ -520,7 +520,7 @@ namespace RockLib.Messaging.CloudEvents
             return senderMessage;
         }
 
-        private void FromReceiverMessage(IReceiverMessage receiverMessage, IProtocolBinding protocolBinding)
+        private void FromReceiverMessage(IReceiverMessage receiverMessage, IProtocolBinding? protocolBinding)
         {
             ProtocolBinding = protocolBinding ?? DefaultProtocolBinding;
 
@@ -569,7 +569,7 @@ namespace RockLib.Messaging.CloudEvents
         /// to render in Binary Mode.
         /// </param>
         /// <returns>The mapped <see cref="HttpRequestMessage"/>.</returns>
-        public HttpRequestMessage ToHttpRequestMessage(string requestUri = null, bool structuredMode = false) =>
+        public HttpRequestMessage ToHttpRequestMessage(string? requestUri = null, bool structuredMode = false) =>
             ToHttpRequestMessage(HttpMethod.Get, requestUri, structuredMode);
 
         /// <summary>
@@ -582,7 +582,7 @@ namespace RockLib.Messaging.CloudEvents
         /// to render in Binary Mode.
         /// </param>
         /// <returns>The mapped <see cref="HttpRequestMessage"/>.</returns>
-        public HttpRequestMessage ToHttpRequestMessage(HttpMethod method, string requestUri = null, bool structuredMode = false)
+        public HttpRequestMessage ToHttpRequestMessage(HttpMethod method, string? requestUri = null, bool structuredMode = false)
         {
             if (method is null)
                 throw new ArgumentNullException(nameof(method));
@@ -648,7 +648,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <exception cref="CloudEventValidationException">
         /// If the <see cref="SenderMessage"/> is not valid.
         /// </exception>
-        public static void Validate(SenderMessage senderMessage, IProtocolBinding protocolBinding = null)
+        public static void Validate(SenderMessage senderMessage, IProtocolBinding? protocolBinding = null)
         {
             if (senderMessage is null)
                 throw new ArgumentNullException(nameof(senderMessage));

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -744,7 +744,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <typeparamref name="T"/> or a type convertible to <typeparamref name="T"/>; otherwise,
         /// <see langword="false"/>.
         /// </returns>
-        protected static bool TryGetHeaderValue<T>(SenderMessage senderMessage, string headerName, out T value)
+        protected static bool TryGetHeaderValue<T>(SenderMessage senderMessage, string headerName, out T? value)
         {
             if (senderMessage.Headers.TryGetValue(headerName, out var objectValue))
             {
@@ -772,7 +772,7 @@ namespace RockLib.Messaging.CloudEvents
                 {
                     try
                     {
-                        value = (T)converter.ConvertFrom(objectValue);
+                        value = (T)converter.ConvertFrom(objectValue)!;
                         return true;
                     }
                     catch
@@ -785,7 +785,7 @@ namespace RockLib.Messaging.CloudEvents
                 {
                     try
                     {
-                        value = (T)converter.ConvertTo(objectValue, typeof(T));
+                        value = (T)converter.ConvertTo(objectValue, typeof(T))!;
                         return true;
                     }
                     catch
@@ -809,8 +809,8 @@ namespace RockLib.Messaging.CloudEvents
         private static DateTime CurrentTime() => DateTime.UtcNow;
 
         private static bool IsStructuredMode(IReceiverMessage receiverMessage) =>
-            receiverMessage.Headers.TryGetValue(StructuredModeContentTypeHeader, out string contentType)
-                && contentType.StartsWith(StructuredModeMediaTypePrefix);
+            receiverMessage.Headers.TryGetValue(StructuredModeContentTypeHeader, out string? contentType)
+            && contentType is not null && contentType.StartsWith(StructuredModeMediaTypePrefix);
 
     }
 }

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -798,9 +798,9 @@ namespace RockLib.Messaging.CloudEvents
             return false;
         }
 
-        internal void SetDataField(string data) => _data = data;
+        internal void SetDataField(string? data) => _data = data;
 
-        internal void SetDataField(byte[] data) => _data = data;
+        internal void SetDataField(byte[]? data) => _data = data;
 
         internal void ClearDataField() => _data = null;
 

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -209,7 +209,10 @@ namespace RockLib.Messaging.CloudEvents
             {
                 if (value != null)
                 {
-                    new Uri(value, UriKind.RelativeOrAbsolute);
+                    if (!Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out _))
+                    {
+                        throw new UriFormatException($"Invalid Uri {value}");
+                    }
                     Attributes[SourceAttribute] = value;
                 }
                 else
@@ -297,7 +300,10 @@ namespace RockLib.Messaging.CloudEvents
             {
                 if (value != null)
                 {
-                    new Uri(value, UriKind.RelativeOrAbsolute);
+                    if (!Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out _))
+                    {
+                        throw new UriFormatException($"Invalid Uri {value}");
+                    }
                     Attributes[DataSchemaAttribute] = value;
                 }
                 else

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -385,7 +385,9 @@ namespace RockLib.Messaging.CloudEvents
         /// <para>To set this value, call the <see cref="CloudEventExtensions.SetData{TCloudEvent}(
         /// TCloudEvent, byte[])"/> extension method.</para>
         /// </summary>
+#pragma warning disable // Properties should not return arrays
         public byte[]? BinaryData => _data as byte[];
+#pragma warning restore // Properties should not return arrays
 
         /// <summary>
         /// Converts the cloud event to a string in the

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -466,7 +466,7 @@ namespace RockLib.Messaging.CloudEvents
                         $"Invalid '{SpecVersionAttribute}' attribute. Expected '{_specVersion1_0}', but was '{attribute.Value}'.");
                 }
 
-                if (attribute.Value is JValue jvalue)
+                if (attribute.Value is JValue jvalue && jvalue.Value is not null)
                     Attributes[attribute.Key] = jvalue.Value;
                 else
                     throw new CloudEventValidationException(

--- a/RockLib.Messaging.CloudEvents/CloudEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEvent.cs
@@ -208,7 +208,7 @@ namespace RockLib.Messaging.CloudEvents
                 : null;
             set
             {
-                if (value != null)
+                if (value is not null)
                 {
                     if (!Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out _))
                     {
@@ -240,7 +240,7 @@ namespace RockLib.Messaging.CloudEvents
                 : null;
             set
             {
-                if (value != null)
+                if (value is not null)
                     Attributes[TypeAttribute] = value;
                 else
                     Attributes.Remove(TypeAttribute);
@@ -258,7 +258,7 @@ namespace RockLib.Messaging.CloudEvents
                 : null;
             set
             {
-                if (value != null)
+                if (value is not null)
                 {
                     _contentType = MediaTypeHeaderValue.Parse(value);
                     Attributes[DataContentTypeAttribute] = value;
@@ -278,7 +278,7 @@ namespace RockLib.Messaging.CloudEvents
         {
             get
             {
-                if (_contentType != null)
+                if (_contentType is not null)
                     return _contentType;
                 if (string.IsNullOrEmpty(DataContentType))
                     return null;
@@ -299,7 +299,7 @@ namespace RockLib.Messaging.CloudEvents
                 : null;
             set
             {
-                if (value != null)
+                if (value is not null)
                 {
                     if (!Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out _))
                     {
@@ -331,7 +331,7 @@ namespace RockLib.Messaging.CloudEvents
                 : null;
             set
             {
-                if (value != null)
+                if (value is not null)
                     Attributes[SubjectAttribute] = value;
                 else
                     Attributes.Remove(SubjectAttribute);
@@ -438,15 +438,15 @@ namespace RockLib.Messaging.CloudEvents
                     if (jvalue.Value is string stringValue)
                         try { _data = Convert.FromBase64String(stringValue); }
                         catch (Exception ex) { throw new CloudEventValidationException("'data_base64' must have a valid base-64 encoded binary value.", ex); }
-                    else if (jvalue.Value != null)
+                    else if (jvalue.Value is not null)
                         throw new CloudEventValidationException("'data_base64' must have a string value.");
                 }
                 else
                     throw new CloudEventValidationException("'data_base64' must have a string value.");
 
-                if (_data != null
+                if (_data is not null
                     && jobject.TryGetValue("data", out token)
-                    && (!(token is JValue jv) || jv.Value != null))
+                    && (!(token is JValue jv) || jv.Value is not null))
                     throw new CloudEventValidationException("'data_base64' and 'data' cannot both have values.");
             }
             
@@ -610,7 +610,7 @@ namespace RockLib.Messaging.CloudEvents
             else
                 request.Content = new StringContent(message.StringPayload);
 
-            if (DataContentType != null)
+            if (DataContentType is not null)
                 request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(DataContentType);
 
             foreach (var header in message.Headers)

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
@@ -33,7 +33,7 @@ namespace RockLib.Messaging.CloudEvents
                 });
             }
 
-            public static CopyConstructor Create(Type type)
+            public static CopyConstructor? Create(Type type)
             {
                 var constructor = GetConstructor(type);
 
@@ -46,7 +46,7 @@ namespace RockLib.Messaging.CloudEvents
             public CloudEvent Invoke(CloudEvent cloudEvent) =>
                 _invokeConstructor(cloudEvent);
 
-            private static ConstructorInfo GetConstructor(Type type) =>
+            private static ConstructorInfo? GetConstructor(Type type) =>
                 type.GetConstructor(new[] { type });
         }
     }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
@@ -23,7 +23,7 @@ namespace RockLib.Messaging.CloudEvents
                     var cloudEventParameter = Expression.Parameter(typeof(CloudEvent), "cloudEvent");
 
                     var body = Expression.New(constructor,
-                        Expression.Convert(cloudEventParameter, constructor.DeclaringType));
+                        Expression.Convert(cloudEventParameter, constructor.DeclaringType!));
 
                     var lamda = Expression.Lambda<Func<CloudEvent, CloudEvent>>(
                         body, cloudEventParameter);

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
@@ -38,7 +38,9 @@ namespace RockLib.Messaging.CloudEvents
                 var constructor = GetConstructor(type);
 
                 if (constructor is null)
+                {
                     return null;
+                }
 
                 return new CopyConstructor(constructor);
             }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
+using System.Threading.Tasks;
 
 namespace RockLib.Messaging.CloudEvents
 {
@@ -18,7 +18,7 @@ namespace RockLib.Messaging.CloudEvents
                     (CloudEvent)constructor.Invoke(new object[] { cloudEvent });
 
                 // Compile the optimized function in the background.
-                ThreadPool.QueueUserWorkItem(_ =>
+                Task.Run(() =>
                 {
                     var cloudEventParameter = Expression.Parameter(typeof(CloudEvent), "cloudEvent");
 

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.CopyConstructor.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading.Tasks;
 
 namespace RockLib.Messaging.CloudEvents
 {
@@ -16,21 +14,6 @@ namespace RockLib.Messaging.CloudEvents
                 // The initial function uses regular reflection.
                 _invokeConstructor = cloudEvent =>
                     (CloudEvent)constructor.Invoke(new object[] { cloudEvent });
-
-                // Compile the optimized function in the background.
-                Task.Run(() =>
-                {
-                    var cloudEventParameter = Expression.Parameter(typeof(CloudEvent), "cloudEvent");
-
-                    var body = Expression.New(constructor,
-                        Expression.Convert(cloudEventParameter, constructor.DeclaringType!));
-
-                    var lamda = Expression.Lambda<Func<CloudEvent, CloudEvent>>(
-                        body, cloudEventParameter);
-
-                    // Replace the reflection function with a compiled function.
-                    _invokeConstructor = lamda.Compile();
-                });
             }
 
             public static CopyConstructor? Create(Type type)

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
+using System.Threading.Tasks;
 
 namespace RockLib.Messaging.CloudEvents
 {
@@ -20,7 +20,7 @@ namespace RockLib.Messaging.CloudEvents
                     constructor.Invoke(new object[] { receiverMessage, protocolBinding! });
 
                 // Compile the optimized function in the background.
-                ThreadPool.QueueUserWorkItem(_ =>
+                Task.Run(() =>
                 {
                     var receiverMessageParameter = Expression.Parameter(typeof(IReceiverMessage), "receiverMessage");
                     var protocolBindingParameter = Expression.Parameter(typeof(IProtocolBinding), "protocolBinding");

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
@@ -35,7 +35,7 @@ namespace RockLib.Messaging.CloudEvents
                 });
             }
 
-            public static MessageConstructor Create(Type type)
+            public static MessageConstructor? Create(Type type)
             {
                 var constructor = GetConstructor(type);
                 
@@ -51,7 +51,7 @@ namespace RockLib.Messaging.CloudEvents
             public object Invoke(IReceiverMessage receiverMessage, IProtocolBinding? protocolBinding) =>
                 _invokeConstructor(receiverMessage, protocolBinding);
 
-            private static ConstructorInfo GetConstructor(Type type) =>
+            private static ConstructorInfo? GetConstructor(Type type) =>
                 type.GetConstructor(_constructorParameters);
         }
     }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
@@ -38,9 +38,11 @@ namespace RockLib.Messaging.CloudEvents
             public static MessageConstructor? Create(Type type)
             {
                 var constructor = GetConstructor(type);
-                
+
                 if (constructor is null)
+                {
                     return null;
+                }
 
                 return new MessageConstructor(constructor);
             }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
@@ -31,7 +31,7 @@ namespace RockLib.Messaging.CloudEvents
             }
 
             public static bool Exists(Type type) =>
-                GetConstructor(type) != null;
+                GetConstructor(type) is not null;
 
             public object Invoke(IReceiverMessage receiverMessage, IProtocolBinding? protocolBinding) =>
                 _invokeConstructor(receiverMessage, protocolBinding);

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading.Tasks;
 
 namespace RockLib.Messaging.CloudEvents
 {
@@ -18,21 +16,6 @@ namespace RockLib.Messaging.CloudEvents
                 // The initial function uses regular reflection.
                 _invokeConstructor = (receiverMessage, protocolBinding) =>
                     constructor.Invoke(new object[] { receiverMessage, protocolBinding! });
-
-                // Compile the optimized function in the background.
-                Task.Run(() =>
-                {
-                    var receiverMessageParameter = Expression.Parameter(typeof(IReceiverMessage), "receiverMessage");
-                    var protocolBindingParameter = Expression.Parameter(typeof(IProtocolBinding), "protocolBinding");
-
-                    var body = Expression.New(constructor, receiverMessageParameter, protocolBindingParameter);
-
-                    var lamda = Expression.Lambda<Func<IReceiverMessage, IProtocolBinding?, object>>(
-                        body, receiverMessageParameter, protocolBindingParameter);
-
-                    // Replace the reflection function with a compiled function.
-                    _invokeConstructor = lamda.Compile();
-                });
             }
 
             public static MessageConstructor? Create(Type type)

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
@@ -17,7 +17,7 @@ namespace RockLib.Messaging.CloudEvents
             {
                 // The initial function uses regular reflection.
                 _invokeConstructor = (receiverMessage, protocolBinding) =>
-                    constructor.Invoke(new object[] { receiverMessage, protocolBinding });
+                    constructor.Invoke(new object[] { receiverMessage, protocolBinding! });
 
                 // Compile the optimized function in the background.
                 ThreadPool.QueueUserWorkItem(_ =>

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
@@ -11,7 +11,7 @@ namespace RockLib.Messaging.CloudEvents
         {
             private static readonly Type[] _constructorParameters = new[] { typeof(IReceiverMessage), typeof(IProtocolBinding) };
 
-            private Func<IReceiverMessage, IProtocolBinding, object> _invokeConstructor;
+            private Func<IReceiverMessage, IProtocolBinding?, object> _invokeConstructor;
 
             private MessageConstructor(ConstructorInfo constructor)
             {
@@ -48,7 +48,7 @@ namespace RockLib.Messaging.CloudEvents
             public static bool Exists(Type type) =>
                 GetConstructor(type) != null;
 
-            public object Invoke(IReceiverMessage receiverMessage, IProtocolBinding protocolBinding) =>
+            public object Invoke(IReceiverMessage receiverMessage, IProtocolBinding? protocolBinding) =>
                 _invokeConstructor(receiverMessage, protocolBinding);
 
             private static ConstructorInfo GetConstructor(Type type) =>

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.MessageConstructor.cs
@@ -27,7 +27,7 @@ namespace RockLib.Messaging.CloudEvents
 
                     var body = Expression.New(constructor, receiverMessageParameter, protocolBindingParameter);
 
-                    var lamda = Expression.Lambda<Func<IReceiverMessage, IProtocolBinding, object>>(
+                    var lamda = Expression.Lambda<Func<IReceiverMessage, IProtocolBinding?, object>>(
                         body, receiverMessageParameter, protocolBindingParameter);
 
                     // Replace the reflection function with a compiled function.

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.ValidateMethod.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.ValidateMethod.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading.Tasks;
 
 namespace RockLib.Messaging.CloudEvents
 {
@@ -19,21 +17,6 @@ namespace RockLib.Messaging.CloudEvents
                 // The initial function uses regular reflection.
                 _invokeValidateMethod = (senderMessage, protocolBinding) =>
                     validateMethod.Invoke(null, new object[] { senderMessage, protocolBinding });
-
-                // Compile the optimized function in the background.
-                Task.Run(() =>
-                {
-                    var senderMessageParameter = Expression.Parameter(typeof(SenderMessage), "senderMessage");
-                    var protocolBindingParameter = Expression.Parameter(typeof(IProtocolBinding), "protocolBinding");
-
-                    var body = Expression.Call(validateMethod, senderMessageParameter, protocolBindingParameter);
-
-                    var lamda = Expression.Lambda<Action<SenderMessage, IProtocolBinding>>(
-                        body, senderMessageParameter, protocolBindingParameter);
-
-                    // Replace the reflection function with a compiled function.
-                    _invokeValidateMethod = lamda.Compile();
-                });
             }
 
             public static ValidateMethod? Create(Type type)

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.ValidateMethod.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.ValidateMethod.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
+using System.Threading.Tasks;
 
 namespace RockLib.Messaging.CloudEvents
 {
@@ -21,7 +21,7 @@ namespace RockLib.Messaging.CloudEvents
                     validateMethod.Invoke(null, new object[] { senderMessage, protocolBinding });
 
                 // Compile the optimized function in the background.
-                ThreadPool.QueueUserWorkItem(_ =>
+                Task.Run(() =>
                 {
                     var senderMessageParameter = Expression.Parameter(typeof(SenderMessage), "senderMessage");
                     var protocolBindingParameter = Expression.Parameter(typeof(IProtocolBinding), "protocolBinding");

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.ValidateMethod.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.ValidateMethod.cs
@@ -41,7 +41,9 @@ namespace RockLib.Messaging.CloudEvents
                 var validateMethod = GetValidateMethod(type);
 
                 if (validateMethod is null)
+                {
                     return null;
+                }
 
                 return new ValidateMethod(validateMethod);
             }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.ValidateMethod.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.ValidateMethod.cs
@@ -36,7 +36,7 @@ namespace RockLib.Messaging.CloudEvents
                 });
             }
 
-            public static ValidateMethod Create(Type type)
+            public static ValidateMethod? Create(Type type)
             {
                 var validateMethod = GetValidateMethod(type);
 
@@ -49,7 +49,7 @@ namespace RockLib.Messaging.CloudEvents
             public void Invoke(SenderMessage senderMessage, IProtocolBinding protocolBinding) =>
                 _invokeValidateMethod(senderMessage, protocolBinding);
 
-            private static MethodInfo GetValidateMethod(Type type) =>
+            private static MethodInfo? GetValidateMethod(Type type) =>
                 type.GetMethod(nameof(CloudEvent.Validate), _publicStaticFlags, null, _validateMethodParameters, null);
         }
     }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -269,7 +269,9 @@ namespace RockLib.Messaging.CloudEvents
                     return true;
                 }
             }
-            catch { }
+            catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException)
+            {
+            }
 
             data = default;
             return false;

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -497,8 +497,8 @@ namespace RockLib.Messaging.CloudEvents
 
             var sb = new StringBuilder();
             var serializer = new XmlSerializer(data.GetType());
-            using (var writer = new StringWriter(sb))
-                serializer.Serialize(writer, data);
+            using var writer = new StringWriter(sb);
+            serializer.Serialize(writer, data);
             return sb.ToString();
         }
 

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -507,7 +507,7 @@ namespace RockLib.Messaging.CloudEvents
 
             var serializer = new XmlSerializer(typeof(T));
             using (var reader = new StringReader(data))
-                return (T)serializer.Deserialize(reader);
+                return (T)serializer.Deserialize(reader)!;
         }
     }
 }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -476,8 +476,8 @@ namespace RockLib.Messaging.CloudEvents
                 }
 
                 return serialization == DataSerialization.Json
-                    ? JsonDeserialize<T>(stringData)!
-                    : XmlDeserialize<T>(stringData)!;
+                    ? JsonDeserialize<T>(stringData!)!
+                    : XmlDeserialize<T>(stringData!)!;
             });
         }
 

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -309,7 +309,7 @@ namespace RockLib.Messaging.CloudEvents
             if (cloudEvent is null)
                 throw new ArgumentNullException(nameof(cloudEvent));
 
-            var copyConstructor = _copyConstructors.GetOrAdd(typeof(TCloudEvent), CopyConstructor.Create)
+            var copyConstructor = _copyConstructors.GetOrAdd(typeof(TCloudEvent), CopyConstructor.Create!)
                 ?? throw MissingCopyConstructor(typeof(TCloudEvent));
 
             return (TCloudEvent)copyConstructor.Invoke(cloudEvent);
@@ -350,7 +350,7 @@ namespace RockLib.Messaging.CloudEvents
             if (receiverMessage is null)
                 throw new ArgumentNullException(nameof(receiverMessage));
 
-            var messageConstructor = _messageConstructors.GetOrAdd(typeof(TCloudEvent), MessageConstructor.Create)
+            var messageConstructor = _messageConstructors.GetOrAdd(typeof(TCloudEvent), MessageConstructor.Create!)
                 ?? throw MissingReceiverConstructor(typeof(TCloudEvent));
 
             return (TCloudEvent)messageConstructor.Invoke(receiverMessage, protocolBinding);
@@ -428,7 +428,7 @@ namespace RockLib.Messaging.CloudEvents
             if (builder is null)
                 throw new ArgumentNullException(nameof(builder));
 
-            var validateMethod = _validateMethods.GetOrAdd(typeof(TCloudEvent), ValidateMethod.Create)
+            var validateMethod = _validateMethods.GetOrAdd(typeof(TCloudEvent), ValidateMethod.Create!)
                 ?? throw MissingValidateMethod(typeof(TCloudEvent));
 
             return builder.AddValidation(message => validateMethod.Invoke(message, protocolBinding!));

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Serialization;
 
 namespace RockLib.Messaging.CloudEvents
@@ -506,8 +507,8 @@ namespace RockLib.Messaging.CloudEvents
                 return null;
 
             var serializer = new XmlSerializer(typeof(T));
-            using (var reader = new StringReader(data))
-                return (T)serializer.Deserialize(reader)!;
+            using var reader = XmlReader.Create(new StringReader(data));
+            return (T)serializer.Deserialize(reader)!;
         }
     }
 }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -502,14 +502,14 @@ namespace RockLib.Messaging.CloudEvents
             {
                 var stringData = evt.StringData;
 
-                if (string.IsNullOrEmpty(stringData))
+                if (string.IsNullOrWhiteSpace(stringData))
                 {
                     if (evt.BinaryData != null)
                     {
                         stringData = Encoding.UTF8.GetString(evt.BinaryData);
                     }
 
-                    if (string.IsNullOrEmpty(stringData))
+                    if (string.IsNullOrWhiteSpace(stringData))
                     {
                         return null!;
                     }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -207,7 +207,7 @@ namespace RockLib.Messaging.CloudEvents
                 return data;
 
             throw new InvalidCastException(
-                $"Unable to cast the CloudEvent's data of type '{dataObject.GetType().FullName}' to type '{typeof(T).FullName}'.");
+                $"Unable to cast the CloudEvent's data of type '{dataObject?.GetType().FullName}' to type '{typeof(T).FullName}'.");
         }
 
         /// <summary>

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -44,7 +44,9 @@ namespace RockLib.Messaging.CloudEvents
             where TCloudEvent : CloudEvent
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
             if (data != cloudEvent.StringData)
             {
@@ -76,7 +78,9 @@ namespace RockLib.Messaging.CloudEvents
             where TCloudEvent : CloudEvent
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
             var binaryData = cloudEvent.BinaryData;
 
@@ -124,9 +128,14 @@ namespace RockLib.Messaging.CloudEvents
             where T : class
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
+
             if (!Enum.IsDefined(typeof(DataSerialization), serialization))
+            {
                 throw new ArgumentOutOfRangeException(nameof(serialization));
+            }
 
             if (data is null)
             {
@@ -198,14 +207,21 @@ namespace RockLib.Messaging.CloudEvents
             where T : class
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
+
             if (!Enum.IsDefined(typeof(DataSerialization), serialization))
+            {
                 throw new ArgumentOutOfRangeException(nameof(serialization));
+            }
 
             var dataObject = cloudEvent.GetDataObject<T>(serialization);
 
             if (dataObject is T data)
+            {
                 return data;
+            }
 
             throw new InvalidCastException(
                 $"Unable to cast the CloudEvent's data of type '{dataObject?.GetType().FullName}' to type '{typeof(T).FullName}'.");
@@ -255,9 +271,14 @@ namespace RockLib.Messaging.CloudEvents
             where T : class
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
+
             if (!Enum.IsDefined(typeof(DataSerialization), serialization))
+            {
                 throw new ArgumentOutOfRangeException(nameof(serialization));
+            }
 
             try
             {
@@ -307,10 +328,12 @@ namespace RockLib.Messaging.CloudEvents
             where TCloudEvent : CloudEvent
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
             var copyConstructor = _copyConstructors.GetOrAdd(typeof(TCloudEvent), CopyConstructor.Create!)
-                ?? throw MissingCopyConstructor(typeof(TCloudEvent));
+                                  ?? throw MissingCopyConstructor(typeof(TCloudEvent));
 
             return (TCloudEvent)copyConstructor.Invoke(cloudEvent);
         }
@@ -348,10 +371,12 @@ namespace RockLib.Messaging.CloudEvents
             where TCloudEvent : CloudEvent
         {
             if (receiverMessage is null)
+            {
                 throw new ArgumentNullException(nameof(receiverMessage));
+            }
 
             var messageConstructor = _messageConstructors.GetOrAdd(typeof(TCloudEvent), MessageConstructor.Create!)
-                ?? throw MissingReceiverConstructor(typeof(TCloudEvent));
+                                     ?? throw MissingReceiverConstructor(typeof(TCloudEvent));
 
             return (TCloudEvent)messageConstructor.Invoke(receiverMessage, protocolBinding);
         }
@@ -387,12 +412,19 @@ namespace RockLib.Messaging.CloudEvents
             where TCloudEvent : CloudEvent
         {
             if (receiver is null)
+            {
                 throw new ArgumentNullException(nameof(receiver));
+            }
+
             if (onEventReceivedAsync is null)
+            {
                 throw new ArgumentNullException(nameof(onEventReceivedAsync));
+            }
 
             if (!MessageConstructor.Exists(typeof(TCloudEvent)))
+            {
                 throw MissingReceiverConstructor(typeof(TCloudEvent));
+            }
 
             receiver.Start(message => onEventReceivedAsync(message.To<TCloudEvent>(protocolBinding), message));
         }
@@ -426,10 +458,12 @@ namespace RockLib.Messaging.CloudEvents
             where TCloudEvent : CloudEvent
         {
             if (builder is null)
+            {
                 throw new ArgumentNullException(nameof(builder));
+            }
 
             var validateMethod = _validateMethods.GetOrAdd(typeof(TCloudEvent), ValidateMethod.Create!)
-                ?? throw MissingValidateMethod(typeof(TCloudEvent));
+                                 ?? throw MissingValidateMethod(typeof(TCloudEvent));
 
             return builder.AddValidation(message => validateMethod.Invoke(message, protocolBinding!));
         }
@@ -456,7 +490,9 @@ namespace RockLib.Messaging.CloudEvents
         private static void ClearDataObject(this CloudEvent cloudEvent)
         {
             if (_dataObjects.TryGetValue(cloudEvent, out _))
+            {
                 _dataObjects.Remove(cloudEvent);
+            }
         }
 
         private static object? GetDataObject<T>(this CloudEvent cloudEvent, DataSerialization serialization)
@@ -469,10 +505,14 @@ namespace RockLib.Messaging.CloudEvents
                 if (string.IsNullOrEmpty(stringData))
                 {
                     if (evt.BinaryData != null)
+                    {
                         stringData = Encoding.UTF8.GetString(evt.BinaryData);
+                    }
 
                     if (string.IsNullOrEmpty(stringData))
+                    {
                         return null!;
+                    }
                 }
 
                 return serialization == DataSerialization.Json
@@ -493,7 +533,9 @@ namespace RockLib.Messaging.CloudEvents
         private static string? XmlSerialize(object data)
         {
             if (data is null)
+            {
                 return null;
+            }
 
             var sb = new StringBuilder();
             var serializer = new XmlSerializer(data.GetType());
@@ -506,7 +548,9 @@ namespace RockLib.Messaging.CloudEvents
             where T : class
         {
             if (data is null)
+            {
                 return null;
+            }
 
             var serializer = new XmlSerializer(typeof(T));
             using var reader = XmlReader.Create(new StringReader(data));

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -456,7 +456,7 @@ namespace RockLib.Messaging.CloudEvents
                 _dataObjects.Remove(cloudEvent);
         }
 
-        private static object GetDataObject<T>(this CloudEvent cloudEvent, DataSerialization serialization)
+        private static object? GetDataObject<T>(this CloudEvent cloudEvent, DataSerialization serialization)
             where T : class
         {
             return _dataObjects.GetValue(cloudEvent, evt =>
@@ -469,12 +469,12 @@ namespace RockLib.Messaging.CloudEvents
                         stringData = Encoding.UTF8.GetString(evt.BinaryData);
 
                     if (string.IsNullOrEmpty(stringData))
-                        return null;
+                        return null!;
                 }
 
                 return serialization == DataSerialization.Json
-                    ? JsonDeserialize<T>(stringData)
-                    : XmlDeserialize<T>(stringData);
+                    ? JsonDeserialize<T>(stringData)!
+                    : XmlDeserialize<T>(stringData)!;
             });
         }
 
@@ -484,10 +484,10 @@ namespace RockLib.Messaging.CloudEvents
         private static string JsonSerialize(object data) =>
             JsonConvert.SerializeObject(data);
 
-        private static T JsonDeserialize<T>(string data) =>
+        private static T? JsonDeserialize<T>(string data) =>
             JsonConvert.DeserializeObject<T>(data);
 
-        private static string XmlSerialize(object data)
+        private static string? XmlSerialize(object data)
         {
             if (data == null)
                 return null;
@@ -499,7 +499,7 @@ namespace RockLib.Messaging.CloudEvents
             return sb.ToString();
         }
 
-        private static T XmlDeserialize<T>(string data)
+        private static T? XmlDeserialize<T>(string data)
             where T : class
         {
             if (data == null)

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -249,7 +249,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <exception cref="ArgumentOutOfRangeException">
         /// If <paramref name="serialization"/> is not defined.
         /// </exception>
-        public static bool TryGetData<T>(this CloudEvent cloudEvent, out T data,
+        public static bool TryGetData<T>(this CloudEvent cloudEvent, out T? data,
             DataSerialization serialization = DataSerialization.Json)
             where T : class
         {

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -478,7 +478,7 @@ namespace RockLib.Messaging.CloudEvents
             });
         }
 
-        internal static bool TryGetDataObject(this CloudEvent cloudEvent, out object data) =>
+        internal static bool TryGetDataObject(this CloudEvent cloudEvent, out object? data) =>
             _dataObjects.TryGetValue(cloudEvent, out data);
 
         private static string JsonSerialize(object data) =>

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -341,7 +341,7 @@ namespace RockLib.Messaging.CloudEvents
         /// with the exact parameters <c>(<see cref="IReceiverMessage"/>, <see cref=
         /// "IProtocolBinding"/>)</c>.
         /// </exception>
-        public static TCloudEvent To<TCloudEvent>(this IReceiverMessage receiverMessage, IProtocolBinding protocolBinding = null)
+        public static TCloudEvent To<TCloudEvent>(this IReceiverMessage receiverMessage, IProtocolBinding? protocolBinding = null)
             where TCloudEvent : CloudEvent
         {
             if (receiverMessage is null)
@@ -380,7 +380,7 @@ namespace RockLib.Messaging.CloudEvents
         /// "IProtocolBinding"/>)</c>.
         /// </exception>
         public static void Start<TCloudEvent>(this IReceiver receiver,
-            Func<TCloudEvent, IReceiverMessage, Task> onEventReceivedAsync, IProtocolBinding protocolBinding = null)
+            Func<TCloudEvent, IReceiverMessage, Task> onEventReceivedAsync, IProtocolBinding? protocolBinding = null)
             where TCloudEvent : CloudEvent
         {
             if (receiver is null)
@@ -419,7 +419,7 @@ namespace RockLib.Messaging.CloudEvents
         /// named "Validate" with the exact parameters <c>(<see cref="SenderMessage"/>, <see cref=
         /// "IProtocolBinding"/>)</c>.
         /// </exception>
-        public static ISenderBuilder AddValidation<TCloudEvent>(this ISenderBuilder builder, IProtocolBinding protocolBinding = null)
+        public static ISenderBuilder AddValidation<TCloudEvent>(this ISenderBuilder builder, IProtocolBinding? protocolBinding = null)
             where TCloudEvent : CloudEvent
         {
             if (builder is null)

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -504,7 +504,7 @@ namespace RockLib.Messaging.CloudEvents
 
                 if (string.IsNullOrWhiteSpace(stringData))
                 {
-                    if (evt.BinaryData != null)
+                    if (evt.BinaryData is not null)
                     {
                         stringData = Encoding.UTF8.GetString(evt.BinaryData);
                     }

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -39,7 +39,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="cloudEvent"/> is <see langword="null"/>.
         /// </exception>
-        public static TCloudEvent SetData<TCloudEvent>(this TCloudEvent cloudEvent, string data)
+        public static TCloudEvent SetData<TCloudEvent>(this TCloudEvent cloudEvent, string? data)
             where TCloudEvent : CloudEvent
         {
             if (cloudEvent is null)
@@ -71,7 +71,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="cloudEvent"/> is <see langword="null"/>.
         /// </exception>
-        public static TCloudEvent SetData<TCloudEvent>(this TCloudEvent cloudEvent, byte[] data)
+        public static TCloudEvent SetData<TCloudEvent>(this TCloudEvent cloudEvent, byte[]? data)
             where TCloudEvent : CloudEvent
         {
             if (cloudEvent is null)
@@ -428,7 +428,7 @@ namespace RockLib.Messaging.CloudEvents
             var validateMethod = _validateMethods.GetOrAdd(typeof(TCloudEvent), ValidateMethod.Create)
                 ?? throw MissingValidateMethod(typeof(TCloudEvent));
 
-            return builder.AddValidation(message => validateMethod.Invoke(message, protocolBinding));
+            return builder.AddValidation(message => validateMethod.Invoke(message, protocolBinding!));
         }
 
         private static MissingMemberException MissingReceiverConstructor(Type cloudEventType) =>
@@ -481,7 +481,7 @@ namespace RockLib.Messaging.CloudEvents
         internal static bool TryGetDataObject(this CloudEvent cloudEvent, out object? data) =>
             _dataObjects.TryGetValue(cloudEvent, out data);
 
-        private static string JsonSerialize(object data) =>
+        private static string? JsonSerialize(object data) =>
             JsonConvert.SerializeObject(data);
 
         private static T? JsonDeserialize<T>(string data) =>

--- a/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventExtensions.cs
@@ -81,7 +81,7 @@ namespace RockLib.Messaging.CloudEvents
             var binaryData = cloudEvent.BinaryData;
 
             if (!ReferenceEquals(binaryData, data)
-                && (binaryData == null || data == null || !binaryData.SequenceEqual(data)))
+                && (binaryData is null || data is null || !binaryData.SequenceEqual(data)))
             {
                 cloudEvent.SetDataField(data);
                 cloudEvent.ClearDataObject();
@@ -492,7 +492,7 @@ namespace RockLib.Messaging.CloudEvents
 
         private static string? XmlSerialize(object data)
         {
-            if (data == null)
+            if (data is null)
                 return null;
 
             var sb = new StringBuilder();
@@ -505,7 +505,7 @@ namespace RockLib.Messaging.CloudEvents
         private static T? XmlDeserialize<T>(string data)
             where T : class
         {
-            if (data == null)
+            if (data is null)
                 return null;
 
             var serializer = new XmlSerializer(typeof(T));

--- a/RockLib.Messaging.CloudEvents/CloudEventValidationException.cs
+++ b/RockLib.Messaging.CloudEvents/CloudEventValidationException.cs
@@ -6,6 +6,7 @@ namespace RockLib.Messaging.CloudEvents
     /// <summary>
     /// The exception that is thrown when validation for a CloudEvent fails.
     /// </summary>
+    [Serializable]
     public class CloudEventValidationException : Exception
     {
         /// <summary>

--- a/RockLib.Messaging.CloudEvents/CorrelatedEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CorrelatedEvent.cs
@@ -43,7 +43,7 @@ namespace RockLib.Messaging.CloudEvents
         /// CloudEvent attributes. If <see langword="null"/>, then <see cref="CloudEvent.DefaultProtocolBinding"/>
         /// is used instead.
         /// </param>
-        public CorrelatedEvent(IReceiverMessage receiverMessage, IProtocolBinding protocolBinding = null)
+        public CorrelatedEvent(IReceiverMessage receiverMessage, IProtocolBinding? protocolBinding = null)
             : base(receiverMessage, protocolBinding)
         {
         }
@@ -92,7 +92,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <exception cref="CloudEventValidationException">
         /// If the <see cref="SenderMessage"/> is not valid.
         /// </exception>
-        public static new void Validate(SenderMessage senderMessage, IProtocolBinding protocolBinding = null)
+        public static new void Validate(SenderMessage senderMessage, IProtocolBinding? protocolBinding = null)
         {
             if (protocolBinding is null)
                 protocolBinding = DefaultProtocolBinding;

--- a/RockLib.Messaging.CloudEvents/CorrelatedEvent.cs
+++ b/RockLib.Messaging.CloudEvents/CorrelatedEvent.cs
@@ -95,13 +95,17 @@ namespace RockLib.Messaging.CloudEvents
         public static new void Validate(SenderMessage senderMessage, IProtocolBinding? protocolBinding = null)
         {
             if (protocolBinding is null)
+            {
                 protocolBinding = DefaultProtocolBinding;
+            }
 
             CloudEvent.Validate(senderMessage, protocolBinding);
 
             var correlationIdHeader = protocolBinding.GetHeaderName(CorrelationIdAttribute);
             if (!ContainsHeader<string>(senderMessage, correlationIdHeader))
+            {
                 senderMessage.Headers[correlationIdHeader] = NewCorrelationId();
+            }
         }
 
         internal static string NewCorrelationId() => Guid.NewGuid().ToString();

--- a/RockLib.Messaging.CloudEvents/Correlating/CorrelatingExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/Correlating/CorrelatingExtensions.cs
@@ -19,10 +19,15 @@ namespace RockLib.Messaging.CloudEvents.Correlating
         public static string GetCorrelationId(this CloudEvent cloudEvent)
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
-            if (cloudEvent.Attributes.TryGetValue(CorrelationIdAttribute, out var value) && value is string correlationId)
+            if (cloudEvent.Attributes.TryGetValue(CorrelationIdAttribute, out var value) &&
+                value is string correlationId)
+            {
                 return correlationId;
+            }
 
             correlationId = NewCorrelationId();
             cloudEvent.Attributes[CorrelationIdAttribute] = correlationId;
@@ -41,9 +46,14 @@ namespace RockLib.Messaging.CloudEvents.Correlating
         public static void SetCorrelationId(this CloudEvent cloudEvent, string correlationId)
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
+
             if (string.IsNullOrEmpty(correlationId))
+            {
                 throw new ArgumentNullException(nameof(correlationId));
+            }
 
             cloudEvent.Attributes[CorrelationIdAttribute] = correlationId;
         }

--- a/RockLib.Messaging.CloudEvents/Directory.Build.props
+++ b/RockLib.Messaging.CloudEvents/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+	</PropertyGroup>
+	<PropertyGroup>
+		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<Authors>Rocket Mortgage</Authors>
+		<Copyright>Copyright 2022 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+		<NoWarn>NU1603,NU1701</NoWarn>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/RockLib.Messaging.CloudEvents/PartitionedEvent.cs
+++ b/RockLib.Messaging.CloudEvents/PartitionedEvent.cs
@@ -52,7 +52,7 @@ namespace RockLib.Messaging.CloudEvents
         /// to CloudEvent attributes. If <see langword="null"/>, then <see cref=
         /// "CloudEvent.DefaultProtocolBinding"/> is used instead.
         /// </param>
-        public PartitionedEvent(IReceiverMessage receiverMessage, IProtocolBinding protocolBinding = null)
+        public PartitionedEvent(IReceiverMessage receiverMessage, IProtocolBinding? protocolBinding = null)
             : base(receiverMessage, protocolBinding)
         {
         }
@@ -105,7 +105,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <exception cref="CloudEventValidationException">
         /// If the <see cref="SenderMessage"/> is not valid.
         /// </exception>
-        public static new void Validate(SenderMessage senderMessage, IProtocolBinding protocolBinding = null)
+        public static new void Validate(SenderMessage senderMessage, IProtocolBinding? protocolBinding = null)
         {
             if (protocolBinding is null)
                 protocolBinding = DefaultProtocolBinding;

--- a/RockLib.Messaging.CloudEvents/PartitionedEvent.cs
+++ b/RockLib.Messaging.CloudEvents/PartitionedEvent.cs
@@ -90,7 +90,9 @@ namespace RockLib.Messaging.CloudEvents
             base.Validate();
 
             if (string.IsNullOrEmpty(PartitionKey))
+            {
                 throw new CloudEventValidationException("PartitionKey cannot be null or empty.");
+            }
         }
 
         /// <summary>
@@ -108,13 +110,18 @@ namespace RockLib.Messaging.CloudEvents
         public static new void Validate(SenderMessage senderMessage, IProtocolBinding? protocolBinding = null)
         {
             if (protocolBinding is null)
+            {
                 protocolBinding = DefaultProtocolBinding;
+            }
 
             CloudEvent.Validate(senderMessage, protocolBinding);
 
             var partitionKeyHeader = protocolBinding.GetHeaderName(PartitionKeyAttribute);
             if (!ContainsHeader<string>(senderMessage, partitionKeyHeader))
-                throw new CloudEventValidationException($"The '{partitionKeyHeader}' header is missing from the SenderMessage.");
+            {
+                throw new CloudEventValidationException(
+                    $"The '{partitionKeyHeader}' header is missing from the SenderMessage.");
+            }
         }
     }
 }

--- a/RockLib.Messaging.CloudEvents/PartitionedEvent.cs
+++ b/RockLib.Messaging.CloudEvents/PartitionedEvent.cs
@@ -89,7 +89,7 @@ namespace RockLib.Messaging.CloudEvents
         {
             base.Validate();
 
-            if (string.IsNullOrEmpty(PartitionKey))
+            if (string.IsNullOrWhiteSpace(PartitionKey))
             {
                 throw new CloudEventValidationException("PartitionKey cannot be null or empty.");
             }

--- a/RockLib.Messaging.CloudEvents/PartitionedEvent.cs
+++ b/RockLib.Messaging.CloudEvents/PartitionedEvent.cs
@@ -78,7 +78,7 @@ namespace RockLib.Messaging.CloudEvents
         /// attribute might change, or even be removed, due to protocol semantics or business
         /// processing logic within each hop.
         /// </summary>
-        public string PartitionKey
+        public string? PartitionKey
         {
             get => this.GetPartitionKey();
             set => this.SetPartitionKey(value);

--- a/RockLib.Messaging.CloudEvents/Partitioning/PartitioningExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/Partitioning/PartitioningExtensions.cs
@@ -23,10 +23,14 @@ namespace RockLib.Messaging.CloudEvents.Partitioning
         public static string? GetPartitionKey(this CloudEvent cloudEvent)
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
             if (cloudEvent.Attributes.TryGetValue(PartitionKeyAttribute, out var value) && value is string key)
+            {
                 return key;
+            }
 
             return null;
         }
@@ -49,12 +53,18 @@ namespace RockLib.Messaging.CloudEvents.Partitioning
         public static void SetPartitionKey(this CloudEvent cloudEvent, string? partitionKey)
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
             if (partitionKey != null)
+            {
                 cloudEvent.Attributes[PartitionKeyAttribute] = partitionKey;
+            }
             else
+            {
                 cloudEvent.Attributes.Remove(PartitionKeyAttribute);
+            }
         }
     }
 }

--- a/RockLib.Messaging.CloudEvents/Partitioning/PartitioningExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/Partitioning/PartitioningExtensions.cs
@@ -46,7 +46,7 @@ namespace RockLib.Messaging.CloudEvents.Partitioning
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="cloudEvent"/> is <see langword="null"/>.
         /// </exception>
-        public static void SetPartitionKey(this CloudEvent cloudEvent, string partitionKey)
+        public static void SetPartitionKey(this CloudEvent cloudEvent, string? partitionKey)
         {
             if (cloudEvent is null)
                 throw new ArgumentNullException(nameof(cloudEvent));

--- a/RockLib.Messaging.CloudEvents/Partitioning/PartitioningExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/Partitioning/PartitioningExtensions.cs
@@ -20,7 +20,7 @@ namespace RockLib.Messaging.CloudEvents.Partitioning
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="cloudEvent"/> is <see langword="null"/>.
         /// </exception>
-        public static string GetPartitionKey(this CloudEvent cloudEvent)
+        public static string? GetPartitionKey(this CloudEvent cloudEvent)
         {
             if (cloudEvent is null)
                 throw new ArgumentNullException(nameof(cloudEvent));

--- a/RockLib.Messaging.CloudEvents/Partitioning/PartitioningExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/Partitioning/PartitioningExtensions.cs
@@ -57,7 +57,7 @@ namespace RockLib.Messaging.CloudEvents.Partitioning
                 throw new ArgumentNullException(nameof(cloudEvent));
             }
 
-            if (partitionKey != null)
+            if (partitionKey is not null)
             {
                 cloudEvent.Attributes[PartitionKeyAttribute] = partitionKey;
             }

--- a/RockLib.Messaging.CloudEvents/ProtocolBindings.cs
+++ b/RockLib.Messaging.CloudEvents/ProtocolBindings.cs
@@ -77,7 +77,7 @@ namespace RockLib.Messaging.CloudEvents
 
             public void Bind(IReceiverMessage fromReceiverMessage, CloudEvent toCloudEvent)
             {
-                if (fromReceiverMessage.Headers.TryGetValue(KafkaKeyHeader, out string kafkaKey))
+                if (fromReceiverMessage.Headers.TryGetValue(KafkaKeyHeader, out string? kafkaKey))
                 {
                     toCloudEvent.Attributes.Remove(KafkaKeyHeader);
                     toCloudEvent.SetPartitionKey(kafkaKey);

--- a/RockLib.Messaging.CloudEvents/ProtocolBindings.cs
+++ b/RockLib.Messaging.CloudEvents/ProtocolBindings.cs
@@ -1,6 +1,5 @@
 ﻿using RockLib.Messaging.CloudEvents.Partitioning;
 using System.Text.RegularExpressions;
-using static RockLib.Messaging.CloudEvents.ProtocolBindings.Constants;
 using static RockLib.Messaging.CloudEvents.PartitionedEvent;
 
 namespace RockLib.Messaging.CloudEvents
@@ -11,22 +10,16 @@ namespace RockLib.Messaging.CloudEvents
     public static class ProtocolBindings
     {
         /// <summary>
-        /// Constants used by protocol binding implementations.
+        /// The name of the header of a <see cref="SenderMessage"/> or <see cref=
+        /// "IReceiverMessage"/> where the Key of a Kafka message is stored.
         /// </summary>
-        public static class Constants
-        {
-            /// <summary>
-            /// The name of the header of a <see cref="SenderMessage"/> or <see cref=
-            /// "IReceiverMessage"/> where the Key of a Kafka message is stored.
-            /// </summary>
-            public const string KafkaKeyHeader = "Kafka.Key";
+        private const string KafkaKeyHeader = "Kafka.Key";
 
-            /// <summary>
-            /// The prefix to apply to the attributes of a <see cref="CloudEvent"/> when converting
-            /// to a <see cref="SenderMessage"/>.
-            /// </summary>
-            public const string KafkaHeaderPrefix = "ce_";
-        }
+        /// <summary>
+        /// The prefix to apply to the attributes of a <see cref="CloudEvent"/> when converting
+        /// to a <see cref="SenderMessage"/>.
+        /// </summary>
+        private const string KafkaHeaderPrefix = "ce_";
 
         /// <summary>
         /// The default protocol binding.

--- a/RockLib.Messaging.CloudEvents/RockLib.Messaging.CloudEvents.csproj
+++ b/RockLib.Messaging.CloudEvents/RockLib.Messaging.CloudEvents.csproj
@@ -1,50 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <DebugType>Embedded</DebugType>
+        <Description>Send and receive messages using the CloudEvents format.</Description>
+        <EmbedUntrackedSources>True</EmbedUntrackedSources>
+        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageId>RockLib.Messaging.CloudEvents</PackageId>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
+        <PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.CloudEvents/CHANGELOG.md.</PackageReleaseNotes>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageTags>rocklib messaging cloudevents</PackageTags>
+        <PackageVersion>1.0.2</PackageVersion>
+        <PublishRepositoryUrl>True</PublishRepositoryUrl>
+        <Version>1.0.0</Version>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.0;net462</TargetFrameworks>
-  </PropertyGroup>
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <PackageId>RockLib.Messaging.CloudEvents</PackageId>
-    <PackageVersion>1.0.2</PackageVersion>
-    <Authors>RockLib</Authors>
-    <Description>Send and receive messages using the CloudEvents format.</Description>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.CloudEvents/CHANGELOG.md.</PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-    <PackageIcon>icon.png</PackageIcon>
-    <Copyright>Copyright 2020-2021 (c) Rocket Mortgage. All rights reserved.</Copyright>
-    <PackageTags>rocklib messaging cloudevents</PackageTags>
-    <Version>1.0.0</Version>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PublishRepositoryUrl>True</PublishRepositoryUrl>
-    <EmbedUntrackedSources>True</EmbedUntrackedSources>
-    <DebugType>Embedded</DebugType>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\LICENSE.md" Pack="true" PackagePath="" />
-    <None Include="..\icon.png" Pack="true" PackagePath="" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="RockLib.Messaging" Version="2.5.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-  </ItemGroup>
-
-  <Import Project="..\RockLib.Messaging.HttpUtils\RockLib.Messaging.HttpUtils.projitems" Label="Shared" />
-
+    <PropertyGroup Condition="'$(Configuration)'=='Release'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <None Include="..\LICENSE.md" Pack="true" PackagePath="" />
+        <None Include="..\icon.png" Pack="true" PackagePath="" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="RockLib.Messaging" Version="3.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    </ItemGroup>
+    
+    <Import Project="..\RockLib.Messaging.HttpUtils\RockLib.Messaging.HttpUtils.projitems" Label="Shared" />
 </Project>

--- a/RockLib.Messaging.CloudEvents/RockLib.Messaging.CloudEvents.csproj
+++ b/RockLib.Messaging.CloudEvents/RockLib.Messaging.CloudEvents.csproj
@@ -37,6 +37,10 @@
         <PackageReference Include="RockLib.Messaging" Version="3.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)'=='net48'">
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    </ItemGroup>
     
     <Import Project="..\RockLib.Messaging.HttpUtils\RockLib.Messaging.HttpUtils.projitems" Label="Shared" />
 </Project>

--- a/RockLib.Messaging.CloudEvents/SequenceTypes.cs
+++ b/RockLib.Messaging.CloudEvents/SequenceTypes.cs
@@ -15,6 +15,8 @@
         /// <item>The sequence wraps around from 2,147,483,647 (2^31 - 1) to -2,147,483,648 (-2^31).</item>
         /// </list>
         /// </summary>
+#pragma warning disable CA1720 // Identifiers should not contain type names
         public const string Integer = "Integer";
+#pragma warning restore CA1720 // Identifiers should not contain type names
     }
 }

--- a/RockLib.Messaging.CloudEvents/Sequencing/SequencingExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/Sequencing/SequencingExtensions.cs
@@ -34,7 +34,7 @@ namespace RockLib.Messaging.CloudEvents.Sequencing
         /// The Sequence of the event. If <see langword="null"/>, the Sequence of the event is
         /// removed.
         /// </param>
-        public static void SetSequence(this CloudEvent cloudEvent, string sequence)
+        public static void SetSequence(this CloudEvent cloudEvent, string? sequence)
         {
             if (cloudEvent is null)
                 throw new ArgumentNullException(nameof(cloudEvent));
@@ -71,7 +71,7 @@ namespace RockLib.Messaging.CloudEvents.Sequencing
         /// The Sequence Type of the event. If <see langword="null"/>, the Sequence Type of the
         /// event is removed.
         /// </param>
-        public static void SetSequenceType(this CloudEvent cloudEvent, string sequenceType)
+        public static void SetSequenceType(this CloudEvent cloudEvent, string? sequenceType)
         {
             if (cloudEvent is null)
                 throw new ArgumentNullException(nameof(cloudEvent));

--- a/RockLib.Messaging.CloudEvents/Sequencing/SequencingExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/Sequencing/SequencingExtensions.cs
@@ -17,10 +17,14 @@ namespace RockLib.Messaging.CloudEvents.Sequencing
         public static string? GetSequence(this CloudEvent cloudEvent)
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
             if (cloudEvent.Attributes.TryGetValue(SequenceAttribute, out var value) && value is string sequence)
+            {
                 return sequence;
+            }
 
             return null;
         }
@@ -37,12 +41,18 @@ namespace RockLib.Messaging.CloudEvents.Sequencing
         public static void SetSequence(this CloudEvent cloudEvent, string? sequence)
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
-            if (sequence != null)
+            if (sequence is not null)
+            {
                 cloudEvent.Attributes[SequenceAttribute] = sequence;
+            }
             else
+            {
                 cloudEvent.Attributes.Remove(SequenceAttribute);
+            }
         }
 
         /// <summary>
@@ -54,10 +64,14 @@ namespace RockLib.Messaging.CloudEvents.Sequencing
         public static string? GetSequenceType(this CloudEvent cloudEvent)
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
             if (cloudEvent.Attributes.TryGetValue(SequenceTypeAttribute, out var value) && value is string sequenceType)
+            {
                 return sequenceType;
+            }
 
             return null;
         }
@@ -74,12 +88,18 @@ namespace RockLib.Messaging.CloudEvents.Sequencing
         public static void SetSequenceType(this CloudEvent cloudEvent, string? sequenceType)
         {
             if (cloudEvent is null)
+            {
                 throw new ArgumentNullException(nameof(cloudEvent));
+            }
 
-            if (sequenceType != null)
+            if (sequenceType is not null)
+            {
                 cloudEvent.Attributes[SequenceTypeAttribute] = sequenceType;
+            }
             else
+            {
                 cloudEvent.Attributes.Remove(SequenceTypeAttribute);
+            }
         }
     }
 }

--- a/RockLib.Messaging.CloudEvents/Sequencing/SequencingExtensions.cs
+++ b/RockLib.Messaging.CloudEvents/Sequencing/SequencingExtensions.cs
@@ -14,7 +14,7 @@ namespace RockLib.Messaging.CloudEvents.Sequencing
         /// </summary>
         /// <param name="cloudEvent">The cloud event.</param>
         /// <returns>The Sequence of the event.</returns>
-        public static string GetSequence(this CloudEvent cloudEvent)
+        public static string? GetSequence(this CloudEvent cloudEvent)
         {
             if (cloudEvent is null)
                 throw new ArgumentNullException(nameof(cloudEvent));
@@ -51,7 +51,7 @@ namespace RockLib.Messaging.CloudEvents.Sequencing
         /// </summary>
         /// <param name="cloudEvent">The cloud event.</param>
         /// <returns>The Sequence Type of the event.</returns>
-        public static string GetSequenceType(this CloudEvent cloudEvent)
+        public static string? GetSequenceType(this CloudEvent cloudEvent)
         {
             if (cloudEvent is null)
                 throw new ArgumentNullException(nameof(cloudEvent));

--- a/RockLib.Messaging.CloudEvents/SequentialEvent.cs
+++ b/RockLib.Messaging.CloudEvents/SequentialEvent.cs
@@ -1,4 +1,5 @@
 ﻿using RockLib.Messaging.CloudEvents.Sequencing;
+using System.Globalization;
 
 namespace RockLib.Messaging.CloudEvents
 {
@@ -43,7 +44,7 @@ namespace RockLib.Messaging.CloudEvents
             if (SequenceType == SequenceTypes.Integer
                 && int.TryParse(source.Sequence, out int sequence))
             {
-                Sequence = unchecked(sequence + 1).ToString();
+                Sequence = unchecked(sequence + 1).ToString(CultureInfo.CurrentCulture);
             }
         }
 

--- a/RockLib.Messaging.CloudEvents/SequentialEvent.cs
+++ b/RockLib.Messaging.CloudEvents/SequentialEvent.cs
@@ -132,10 +132,10 @@ namespace RockLib.Messaging.CloudEvents
             CloudEvent.Validate(senderMessage, protocolBinding);
 
             var sequenceHeader = protocolBinding.GetHeaderName(SequenceAttribute);
-            if (TryGetHeaderValue(senderMessage, sequenceHeader, out string sequence))
+            if (TryGetHeaderValue(senderMessage, sequenceHeader, out string? sequence))
             {
                 var sequenceTypeHeader = protocolBinding.GetHeaderName(SequenceTypeAttribute);
-                if (TryGetHeaderValue(senderMessage, sequenceTypeHeader, out string sequenceType)
+                if (TryGetHeaderValue(senderMessage, sequenceTypeHeader, out string? sequenceType)
                     && sequenceType == SequenceTypes.Integer
                     && !int.TryParse(sequence, out _))
                 {

--- a/RockLib.Messaging.CloudEvents/SequentialEvent.cs
+++ b/RockLib.Messaging.CloudEvents/SequentialEvent.cs
@@ -60,7 +60,7 @@ namespace RockLib.Messaging.CloudEvents
         /// CloudEvent attributes. If <see langword="null"/>, then <see cref="CloudEvent.DefaultProtocolBinding"/>
         /// is used instead.
         /// </param>
-        public SequentialEvent(IReceiverMessage receiverMessage, IProtocolBinding protocolBinding = null)
+        public SequentialEvent(IReceiverMessage receiverMessage, IProtocolBinding? protocolBinding = null)
             : base(receiverMessage, protocolBinding)
         {
         }
@@ -124,7 +124,7 @@ namespace RockLib.Messaging.CloudEvents
         /// <exception cref="CloudEventValidationException">
         /// If the <see cref="SenderMessage"/> is not valid.
         /// </exception>
-        public static new void Validate(SenderMessage senderMessage, IProtocolBinding protocolBinding = null)
+        public static new void Validate(SenderMessage senderMessage, IProtocolBinding? protocolBinding = null)
         {
             if (protocolBinding is null)
                 protocolBinding = DefaultProtocolBinding;

--- a/RockLib.Messaging.CloudEvents/SequentialEvent.cs
+++ b/RockLib.Messaging.CloudEvents/SequentialEvent.cs
@@ -83,7 +83,7 @@ namespace RockLib.Messaging.CloudEvents
         /// REQUIRED. Value expressing the relative order of the event. This enables interpretation of
         /// data supercedence.
         /// </summary>
-        public string Sequence
+        public string? Sequence
         {
             get => this.GetSequence();
             set => this.SetSequence(value);
@@ -93,7 +93,7 @@ namespace RockLib.Messaging.CloudEvents
         /// Specifies the semantics of the sequence attribute. See the <see cref="SequenceTypes"/> class
         /// for known values of this attribute.
         /// </summary>
-        public string SequenceType
+        public string? SequenceType
         {
             get => this.GetSequenceType();
             set => this.SetSequenceType(value);

--- a/RockLib.Messaging.CloudEvents/SequentialEvent.cs
+++ b/RockLib.Messaging.CloudEvents/SequentialEvent.cs
@@ -106,11 +106,16 @@ namespace RockLib.Messaging.CloudEvents
             base.Validate();
 
             if (string.IsNullOrEmpty(Sequence))
+            {
                 throw new CloudEventValidationException("Sequence cannot be null or empty.");
+            }
 
             if (SequenceType == SequenceTypes.Integer
                 && !int.TryParse(Sequence, out _))
-                throw new CloudEventValidationException($"Invalid valid for Sequence: '{Sequence}'. Because SequenceType is '{SequenceTypes.Integer}', the Sequence property must be a valid string encoded 32-bit signed integer");
+            {
+                throw new CloudEventValidationException(
+                    $"Invalid valid for Sequence: '{Sequence}'. Because SequenceType is '{SequenceTypes.Integer}', the Sequence property must be a valid string encoded 32-bit signed integer");
+            }
         }
 
         /// <summary>
@@ -128,7 +133,9 @@ namespace RockLib.Messaging.CloudEvents
         public static new void Validate(SenderMessage senderMessage, IProtocolBinding? protocolBinding = null)
         {
             if (protocolBinding is null)
+            {
                 protocolBinding = DefaultProtocolBinding;
+            }
 
             CloudEvent.Validate(senderMessage, protocolBinding);
 

--- a/RockLib.Messaging.CloudEvents/SequentialEvent.cs
+++ b/RockLib.Messaging.CloudEvents/SequentialEvent.cs
@@ -105,7 +105,7 @@ namespace RockLib.Messaging.CloudEvents
         {
             base.Validate();
 
-            if (string.IsNullOrEmpty(Sequence))
+            if (string.IsNullOrWhiteSpace(Sequence))
             {
                 throw new CloudEventValidationException("Sequence cannot be null or empty.");
             }

--- a/RockLib.Messaging.CloudEvents/appveyor.yml
+++ b/RockLib.Messaging.CloudEvents/appveyor.yml
@@ -1,5 +1,5 @@
 version: 'RockLib.Messaging.CloudEvents.{build}.0.0-ci'
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 only_commits:
   files:

--- a/RockLib.Messaging.HttpUtils/HttpUtils.cs
+++ b/RockLib.Messaging.HttpUtils/HttpUtils.cs
@@ -8,7 +8,7 @@ namespace RockLib.Messaging
 {
     internal static class HttpUtils
     {
-        public static void AddHeader(HttpHeaders headers, string headerName, string headerValue)
+        public static void AddHeader(HttpHeaders headers, string headerName, string? headerValue)
         {
             if (headerValue == null)
                 return;
@@ -70,7 +70,7 @@ namespace RockLib.Messaging
             }
         }
 
-        private static IEnumerable<string> SplitByComma(string headerValue)
+        private static IEnumerable<string> SplitByComma(string? headerValue)
         {
             string value;
 #if NET48

--- a/RockLib.Messaging.HttpUtils/HttpUtils.cs
+++ b/RockLib.Messaging.HttpUtils/HttpUtils.cs
@@ -73,6 +73,12 @@ namespace RockLib.Messaging
         private static IEnumerable<string> SplitByComma(string? headerValue)
         {
             string value;
+
+            if (headerValue is null)
+            {
+                yield break;
+            }
+
 #if NET48
             if (!headerValue.Contains(','))
 #else

--- a/RockLib.Messaging.HttpUtils/HttpUtils.cs
+++ b/RockLib.Messaging.HttpUtils/HttpUtils.cs
@@ -79,7 +79,7 @@ namespace RockLib.Messaging
             }
 
 #if NET48
-            if (!headerValue.Contains(','))
+            if (!headerValue.Contains(","))
 #else
             if (!headerValue.Contains(',', StringComparison.InvariantCultureIgnoreCase))
 #endif

--- a/RockLib.Messaging.HttpUtils/HttpUtils.cs
+++ b/RockLib.Messaging.HttpUtils/HttpUtils.cs
@@ -9,13 +9,19 @@ namespace RockLib.Messaging
     {
         public static void AddHeader(HttpHeaders headers, string headerName, string? headerValue)
         {
-            if (headerValue == null)
+            if (headerValue is null)
+            {
                 return;
+            }
 
             if (SupportsMultipleValues(headerName))
+            {
                 headers.Add(headerName, SplitByComma(headerValue));
+            }
             else
+            {
                 headers.Add(headerName, headerValue);
+            }
         }
 
         public static bool IsContentHeader(string headerName)
@@ -86,7 +92,10 @@ namespace RockLib.Messaging
             {
                 value = headerValue.Trim();
                 if (value.Length > 0)
+                {
                     yield return value;
+                }
+
                 yield break;
             }
 
@@ -112,7 +121,9 @@ namespace RockLib.Messaging
             {
                 value = sb.ToString().Trim();
                 if (value.Length > 0)
+                {
                     yield return value;
+                }
             }
         }
     }

--- a/RockLib.Messaging.HttpUtils/HttpUtils.cs
+++ b/RockLib.Messaging.HttpUtils/HttpUtils.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/.editorconfig
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/.editorconfig
@@ -1,0 +1,69 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.cs]
+# Styling
+indent_style = space
+indent_size = 4
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = false
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = methods, control_blocks, types, properties, lambdas, accessors, object_collection_array_initializers
+csharp_new_line_between_query_expression_clauses = true
+csharp_prefer_braces = false:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_preferred_modifier_order = public,private,internal,protected,static,readonly,async,override,sealed:suggestion
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+dotnet_sort_system_directives_first = false
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = false:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+
+# Analyzer Configuration
+# These are rules we want to either ignore or have set as suggestion or info
+
+# CA1014: Mark assemblies with CLSCompliant
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# CA1725: Parameter names should match base declaration
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA2227: Collection properties should be read only
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = suggestion

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/AssemblySettings.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/AssemblySettings.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -43,7 +43,8 @@ namespace RockLib.Messaging.CloudEvents.Tests
             // In order to verify that the method did not clear the data object, there needs to be one first.
             _dataObjects.Add(cloudEvent, new object());
 
-            cloudEvent.SetData($"Hello, {"WORLD".ToLowerInvariant()}!");
+            // SetData to the same to check that it does not change and also not get removed from _dataObjects
+            cloudEvent.SetData($"Hello, world!");
 
             string data = cloudEvent.Unlock()._data;
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -44,7 +44,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             _dataObjects.Add(cloudEvent, new object());
 
             // SetData to the same to check that it does not change and also not get removed from _dataObjects
-            cloudEvent.SetData($"Hello, world!");
+            cloudEvent.SetData("Hello, world!");
 
             string data = cloudEvent.Unlock()._data;
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -400,12 +400,12 @@ namespace RockLib.Messaging.CloudEvents.Tests
             return sb.ToString();
         }
 
-        public class Client
+        private class Client
         {
             public string? FirstName { get; set; }
             public string? LastName { get; set; }
         }
 
-        public class NotAClient { }
+        private class NotAClient { }
     }
 }

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -306,7 +306,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.Unlock()._data = clientData;
 
-            cloudEvent.TryGetData(out Client client).Should().BeTrue();
+            cloudEvent.TryGetData(out Client? client).Should().BeTrue();
 
             client.FirstName.Should().Be("Brian");
             client.LastName.Should().Be("Friesen");
@@ -320,7 +320,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.Unlock()._data = clientData;
 
-            cloudEvent.TryGetData(out Client client, DataSerialization.Xml).Should().BeTrue();
+            cloudEvent.TryGetData(out Client? client, DataSerialization.Xml).Should().BeTrue();
 
             client.FirstName.Should().Be("Brian");
             client.LastName.Should().Be("Friesen");
@@ -334,7 +334,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             _dataObjects.Add(cloudEvent, client);
 
-            cloudEvent.TryGetData(out Client actualClient).Should().BeTrue();
+            cloudEvent.TryGetData(out Client? actualClient).Should().BeTrue();
             actualClient.Should().BeSameAs(client);
         }
 
@@ -343,7 +343,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             CloudEvent cloudEvent = null!;
 
-            Action act = () => cloudEvent.TryGetData(out Client client);
+            Action act = () => cloudEvent.TryGetData(out Client? client);
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*cloudEvent*");
         }
@@ -354,7 +354,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent();
             var serialization = (DataSerialization)(-123);
 
-            Action act = () => cloudEvent.TryGetData(out Client client, serialization);
+            Action act = () => cloudEvent.TryGetData(out Client? client, serialization);
 
             act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithMessage("*serialization*");
         }
@@ -366,7 +366,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.Unlock()._data = "Not valid JSON";
 
-            cloudEvent.TryGetData(out Client _).Should().BeFalse();
+            cloudEvent.TryGetData(out Client? _).Should().BeFalse();
         }
 
         [Fact(DisplayName = "TryGetData method returns false if StringData is invalid XML")]
@@ -376,7 +376,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.Unlock()._data = "Not valid JSON";
 
-            cloudEvent.TryGetData(out Client _, DataSerialization.Xml).Should().BeFalse();
+            cloudEvent.TryGetData(out Client? _, DataSerialization.Xml).Should().BeFalse();
         }
 
         [Fact(DisplayName = "TryGetData method returns false if data object already exists and cannot be cast to T")]
@@ -386,7 +386,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             _dataObjects.Add(cloudEvent, new NotAClient());
 
-            cloudEvent.TryGetData(out Client _).Should().BeFalse();
+            cloudEvent.TryGetData(out Client? _).Should().BeFalse();
         }
 
         private static string XmlSerialize(Client client)

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -54,7 +54,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "SetData method 1 throws if cloudEvent is null")]
         public void SetDataMethod1SadPath()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.SetData("Hello, world!");
 
@@ -121,7 +121,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "SetData method 2 throws if cloudEvent is null")]
         public void SetDataMethod2SadPath()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.SetData(new byte[] { 1, 2, 3, 4 });
 
@@ -169,7 +169,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             // In order to verify that the method cleared the data object, there needs to be one first.
             _dataObjects.Add(cloudEvent, new object());
 
-            Client client = null;
+            Client client = null!;
 
             cloudEvent.SetData(client);
 
@@ -182,7 +182,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "SetData method 3 throws if cloudEvent is null")]
         public void SetDataMethod3SadPath1()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
             var client = new Client { FirstName = "Brian", LastName = "Friesen" };
 
             Action act = () => cloudEvent.SetData(client);
@@ -244,7 +244,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "GetData method throws if cloudEvent is null")]
         public void GetDataMethodSadPath1()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.GetData<Client>();
 
@@ -341,7 +341,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "TryGetData method throws if cloudEvent is null")]
         public void TryGetDataMethodSadPath1()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.TryGetData(out Client client);
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -402,8 +402,8 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
         public class Client
         {
-            public string FirstName { get; set; }
-            public string LastName { get; set; }
+            public string? FirstName { get; set; }
+            public string? LastName { get; set; }
         }
 
         public class NotAClient { }

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -133,7 +133,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void SetDataMethod3HappyPath1()
         {
             var cloudEvent = new CloudEvent();
-            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
 
             cloudEvent.SetData(client);
 
@@ -148,7 +148,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void SetDataMethod3HappyPath2()
         {
             var cloudEvent = new CloudEvent();
-            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
 
             cloudEvent.SetData(client, DataSerialization.Xml);
 
@@ -170,9 +170,9 @@ namespace RockLib.Messaging.CloudEvents.Tests
             // In order to verify that the method cleared the data object, there needs to be one first.
             _dataObjects.Add(cloudEvent, new object());
 
-            Client client = null!;
+            TestClient testClient = null!;
 
-            cloudEvent.SetData(client);
+            cloudEvent.SetData(testClient);
 
             object data = cloudEvent.Unlock()._data;
 
@@ -184,7 +184,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void SetDataMethod3SadPath1()
         {
             CloudEvent cloudEvent = null!;
-            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
 
             Action act = () => cloudEvent.SetData(client);
 
@@ -195,7 +195,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void SetDataMethod3SadPath2()
         {
             var cloudEvent = new CloudEvent();
-            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
             var serialization = (DataSerialization)(-123);
 
             Action act = () => cloudEvent.SetData(client, serialization);
@@ -207,11 +207,11 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void GetDataMethodHappyPath1()
         {
             var cloudEvent = new CloudEvent();
-            var clientData = JsonConvert.SerializeObject(new Client { FirstName = "Brian", LastName = "Friesen" });
+            var clientData = JsonConvert.SerializeObject(new TestClient { FirstName = "Brian", LastName = "Friesen" });
 
             cloudEvent.Unlock()._data = clientData;
 
-            var client = cloudEvent.GetData<Client>();
+            var client = cloudEvent.GetData<TestClient>();
 
             client.FirstName.Should().Be("Brian");
             client.LastName.Should().Be("Friesen");
@@ -221,11 +221,11 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void GetDataMethodHappyPath2()
         {
             var cloudEvent = new CloudEvent();
-            var clientData = XmlSerialize(new Client { FirstName = "Brian", LastName = "Friesen" });
+            var clientData = XmlSerialize(new TestClient { FirstName = "Brian", LastName = "Friesen" });
 
             cloudEvent.Unlock()._data = clientData;
 
-            var client = cloudEvent.GetData<Client>(DataSerialization.Xml);
+            var client = cloudEvent.GetData<TestClient>(DataSerialization.Xml);
 
             client.FirstName.Should().Be("Brian");
             client.LastName.Should().Be("Friesen");
@@ -235,11 +235,11 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void GetDataMethodHappyPath3()
         {
             var cloudEvent = new CloudEvent();
-            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
 
             _dataObjects.Add(cloudEvent, client);
 
-            cloudEvent.GetData<Client>().Should().BeSameAs(client);
+            cloudEvent.GetData<TestClient>().Should().BeSameAs(client);
         }
 
         [Fact(DisplayName = "GetData method throws if cloudEvent is null")]
@@ -247,7 +247,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             CloudEvent cloudEvent = null!;
 
-            Action act = () => cloudEvent.GetData<Client>();
+            Action act = () => cloudEvent.GetData<TestClient>();
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*cloudEvent*");
         }
@@ -258,7 +258,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent();
             var serialization = (DataSerialization)(-123);
 
-            Action act = () => cloudEvent.GetData<Client>(serialization);
+            Action act = () => cloudEvent.GetData<TestClient>(serialization);
 
             act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithMessage("*serialization*");
         }
@@ -270,7 +270,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.Unlock()._data = "Not valid JSON";
 
-            Action act = () => cloudEvent.GetData<Client>();
+            Action act = () => cloudEvent.GetData<TestClient>();
 
             act.Should().Throw<JsonException>();
         }
@@ -282,7 +282,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.Unlock()._data = "Not valid JSON";
 
-            Action act = () => cloudEvent.GetData<Client>(DataSerialization.Xml);
+            Action act = () => cloudEvent.GetData<TestClient>(DataSerialization.Xml);
 
             act.Should().Throw<InvalidOperationException>();
         }
@@ -294,7 +294,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             _dataObjects.Add(cloudEvent, new NotAClient());
 
-            Action act = () => cloudEvent.GetData<Client>();
+            Action act = () => cloudEvent.GetData<TestClient>();
 
             act.Should().ThrowExactly<InvalidCastException>();
         }
@@ -303,11 +303,11 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void TryGetDataMethodHappyPath1()
         {
             var cloudEvent = new CloudEvent();
-            var clientData = JsonConvert.SerializeObject(new Client { FirstName = "Brian", LastName = "Friesen" });
+            var clientData = JsonConvert.SerializeObject(new TestClient { FirstName = "Brian", LastName = "Friesen" });
 
             cloudEvent.Unlock()._data = clientData;
 
-            cloudEvent.TryGetData(out Client? client).Should().BeTrue();
+            cloudEvent.TryGetData(out TestClient? client).Should().BeTrue();
 
             cloudEvent.Should().NotBeNull();
             client!.FirstName.Should().Be("Brian");
@@ -318,11 +318,11 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void TryGetDataMethodHappyPath2()
         {
             var cloudEvent = new CloudEvent();
-            var clientData = XmlSerialize(new Client { FirstName = "Brian", LastName = "Friesen" });
+            var clientData = XmlSerialize(new TestClient { FirstName = "Brian", LastName = "Friesen" });
 
             cloudEvent.Unlock()._data = clientData;
 
-            cloudEvent.TryGetData(out Client? client, DataSerialization.Xml).Should().BeTrue();
+            cloudEvent.TryGetData(out TestClient? client, DataSerialization.Xml).Should().BeTrue();
 
             client.Should().NotBeNull();
             client!.FirstName.Should().Be("Brian");
@@ -333,11 +333,11 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void TryGetDataMethodHappyPath3()
         {
             var cloudEvent = new CloudEvent();
-            var client = new Client { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
 
             _dataObjects.Add(cloudEvent, client);
 
-            cloudEvent.TryGetData(out Client? actualClient).Should().BeTrue();
+            cloudEvent.TryGetData(out TestClient? actualClient).Should().BeTrue();
             actualClient.Should().BeSameAs(client);
         }
 
@@ -346,7 +346,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             CloudEvent cloudEvent = null!;
 
-            Action act = () => cloudEvent.TryGetData(out Client? client);
+            Action act = () => cloudEvent.TryGetData(out TestClient? client);
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*cloudEvent*");
         }
@@ -357,7 +357,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent();
             var serialization = (DataSerialization)(-123);
 
-            Action act = () => cloudEvent.TryGetData(out Client? client, serialization);
+            Action act = () => cloudEvent.TryGetData(out TestClient? client, serialization);
 
             act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithMessage("*serialization*");
         }
@@ -369,7 +369,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.Unlock()._data = "Not valid JSON";
 
-            cloudEvent.TryGetData(out Client? _).Should().BeFalse();
+            cloudEvent.TryGetData(out TestClient? _).Should().BeFalse();
         }
 
         [Fact(DisplayName = "TryGetData method returns false if StringData is invalid XML")]
@@ -379,7 +379,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.Unlock()._data = "Not valid JSON";
 
-            cloudEvent.TryGetData(out Client? _, DataSerialization.Xml).Should().BeFalse();
+            cloudEvent.TryGetData(out TestClient? _, DataSerialization.Xml).Should().BeFalse();
         }
 
         [Fact(DisplayName = "TryGetData method returns false if data object already exists and cannot be cast to T")]
@@ -389,24 +389,28 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             _dataObjects.Add(cloudEvent, new NotAClient());
 
-            cloudEvent.TryGetData(out Client? _).Should().BeFalse();
+            cloudEvent.TryGetData(out TestClient? _).Should().BeFalse();
         }
 
-        private static string XmlSerialize(Client client)
+        private static string XmlSerialize(TestClient testClient)
         {
             var sb = new StringBuilder();
-            var serializer = new XmlSerializer(typeof(Client));
+            var serializer = new XmlSerializer(typeof(TestClient));
             using (var writer = new StringWriter(sb))
-                serializer.Serialize(writer, client);
+                serializer.Serialize(writer, testClient);
             return sb.ToString();
         }
 
-        private class Client
+#pragma warning disable CA1034 // Do not nest types
+        public class TestClient
+#pragma warning restore CA1034 // Do not nest types
         {
             public string? FirstName { get; set; }
             public string? LastName { get; set; }
         }
 
-        private class NotAClient { }
+#pragma warning disable CA1034 // Do not nest types
+        public class NotAClient { }
+#pragma warning restore CA1034 // Do not nest types
     }
 }

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -133,7 +133,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void SetDataMethod3HappyPath1()
         {
             var cloudEvent = new CloudEvent();
-            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "First", LastName = "Last" };
 
             cloudEvent.SetData(client);
 
@@ -148,7 +148,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void SetDataMethod3HappyPath2()
         {
             var cloudEvent = new CloudEvent();
-            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "First", LastName = "Last" };
 
             cloudEvent.SetData(client, DataSerialization.Xml);
 
@@ -184,7 +184,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void SetDataMethod3SadPath1()
         {
             CloudEvent cloudEvent = null!;
-            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "First", LastName = "Last" };
 
             Action act = () => cloudEvent.SetData(client);
 
@@ -195,7 +195,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void SetDataMethod3SadPath2()
         {
             var cloudEvent = new CloudEvent();
-            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "First", LastName = "Last" };
             var serialization = (DataSerialization)(-123);
 
             Action act = () => cloudEvent.SetData(client, serialization);
@@ -207,35 +207,35 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void GetDataMethodHappyPath1()
         {
             var cloudEvent = new CloudEvent();
-            var clientData = JsonConvert.SerializeObject(new TestClient { FirstName = "Brian", LastName = "Friesen" });
+            var clientData = JsonConvert.SerializeObject(new TestClient { FirstName = "First", LastName = "Last" });
 
             cloudEvent.Unlock()._data = clientData;
 
             var client = cloudEvent.GetData<TestClient>();
 
-            client.FirstName.Should().Be("Brian");
-            client.LastName.Should().Be("Friesen");
+            client.FirstName.Should().Be("First");
+            client.LastName.Should().Be("Last");
         }
 
         [Fact(DisplayName = "GetData method XML deserializes StringData")]
         public void GetDataMethodHappyPath2()
         {
             var cloudEvent = new CloudEvent();
-            var clientData = XmlSerialize(new TestClient { FirstName = "Brian", LastName = "Friesen" });
+            var clientData = XmlSerialize(new TestClient { FirstName = "First", LastName = "Last" });
 
             cloudEvent.Unlock()._data = clientData;
 
             var client = cloudEvent.GetData<TestClient>(DataSerialization.Xml);
 
-            client.FirstName.Should().Be("Brian");
-            client.LastName.Should().Be("Friesen");
+            client.FirstName.Should().Be("First");
+            client.LastName.Should().Be("Last");
         }
 
         [Fact(DisplayName = "GetData method returns data object if it already exists")]
         public void GetDataMethodHappyPath3()
         {
             var cloudEvent = new CloudEvent();
-            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "First", LastName = "Last" };
 
             _dataObjects.Add(cloudEvent, client);
 
@@ -303,37 +303,37 @@ namespace RockLib.Messaging.CloudEvents.Tests
         public void TryGetDataMethodHappyPath1()
         {
             var cloudEvent = new CloudEvent();
-            var clientData = JsonConvert.SerializeObject(new TestClient { FirstName = "Brian", LastName = "Friesen" });
+            var clientData = JsonConvert.SerializeObject(new TestClient { FirstName = "First", LastName = "Last" });
 
             cloudEvent.Unlock()._data = clientData;
 
             cloudEvent.TryGetData(out TestClient? client).Should().BeTrue();
 
             cloudEvent.Should().NotBeNull();
-            client!.FirstName.Should().Be("Brian");
-            client!.LastName.Should().Be("Friesen");
+            client!.FirstName.Should().Be("First");
+            client!.LastName.Should().Be("Last");
         }
 
         [Fact(DisplayName = "TryGetData method XML deserializes StringData")]
         public void TryGetDataMethodHappyPath2()
         {
             var cloudEvent = new CloudEvent();
-            var clientData = XmlSerialize(new TestClient { FirstName = "Brian", LastName = "Friesen" });
+            var clientData = XmlSerialize(new TestClient { FirstName = "First", LastName = "Last" });
 
             cloudEvent.Unlock()._data = clientData;
 
             cloudEvent.TryGetData(out TestClient? client, DataSerialization.Xml).Should().BeTrue();
 
             client.Should().NotBeNull();
-            client!.FirstName.Should().Be("Brian");
-            client.LastName.Should().Be("Friesen");
+            client!.FirstName.Should().Be("First");
+            client.LastName.Should().Be("Last");
         }
 
         [Fact(DisplayName = "TryGetData method returns data object if it already exists")]
         public void TryGetDataMethodHappyPath3()
         {
             var cloudEvent = new CloudEvent();
-            var client = new TestClient { FirstName = "Brian", LastName = "Friesen" };
+            var client = new TestClient { FirstName = "First", LastName = "Last" };
 
             _dataObjects.Add(cloudEvent, client);
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -396,8 +396,8 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             var sb = new StringBuilder();
             var serializer = new XmlSerializer(typeof(TestClient));
-            using (var writer = new StringWriter(sb))
-                serializer.Serialize(writer, testClient);
+            using var writer = new StringWriter(sb);
+            serializer.Serialize(writer, testClient);
             return sb.ToString();
         }
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventExtensionsTests.cs
@@ -308,8 +308,9 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.TryGetData(out Client? client).Should().BeTrue();
 
-            client.FirstName.Should().Be("Brian");
-            client.LastName.Should().Be("Friesen");
+            cloudEvent.Should().NotBeNull();
+            client!.FirstName.Should().Be("Brian");
+            client!.LastName.Should().Be("Friesen");
         }
 
         [Fact(DisplayName = "TryGetData method XML deserializes StringData")]
@@ -322,7 +323,8 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.TryGetData(out Client? client, DataSerialization.Xml).Should().BeTrue();
 
-            client.FirstName.Should().Be("Brian");
+            client.Should().NotBeNull();
+            client!.FirstName.Should().Be("Brian");
             client.LastName.Should().Be("Friesen");
         }
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -57,7 +57,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             CloudEvent source = null!;
 
-            Action act = () => new CloudEvent(source);
+            Action act = () =>
+            {
+                var _ = new CloudEvent(source);
+            };
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*source*");
         }
@@ -205,7 +208,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Null receiverMessage
 
-            Action act = () => new CloudEvent((IReceiverMessage)null!);
+            Action act = () =>
+            {
+                var _ = new CloudEvent((IReceiverMessage)null!);
+            };
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*receiverMessage*");
         }
@@ -218,7 +224,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
             using var receiverMessage = new FakeReceiverMessage("Hello, world!");
             receiverMessage.Headers.Add(CloudEvent.SpecVersionAttribute, "0.0");
 
-            Action act = () => new CloudEvent(receiverMessage);
+            Action act = () =>
+            {
+                var _ = new CloudEvent(receiverMessage);
+            };
 
             act.Should().ThrowExactly<CloudEventValidationException>();
         }
@@ -325,7 +334,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Null jsonFormattedCloudEvent
 
-            Action act = () => new CloudEvent((string)null!);
+            Action act = () =>
+            {
+                var _ = new CloudEvent((string)null!);
+            };
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*jsonFormattedCloudEvent*");
         }
@@ -335,7 +347,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Empty jsonFormattedCloudEvent
 
-            Action act = () => new CloudEvent("");
+            Action act = () =>
+            {
+                var _ = new CloudEvent("");
+            };
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*jsonFormattedCloudEvent*");
         }
@@ -347,7 +362,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var json = "{\"specversion\":\"0.0\",\"data\":\"abc\"}";
 
-            Action act = () => new CloudEvent(json);
+            Action act = () =>
+            {
+                var _ = new CloudEvent(json);
+            };
 
             act.Should().ThrowExactly<CloudEventValidationException>().WithMessage("Invalid 'specversion' attribute*");
         }
@@ -362,7 +380,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var json = $"{{\"data_base64\":{data_base64}}}";
 
-            Action act = () => new CloudEvent(json);
+            Action act = () =>
+            {
+                var _ = new CloudEvent(json);
+            };
 
             act.Should().ThrowExactly<CloudEventValidationException>().WithMessage("'data_base64' must have a string value.");
         }
@@ -374,7 +395,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var json = "{\"data_base64\":\"Hello, world!\"}";
 
-            Action act = () => new CloudEvent(json);
+            Action act = () =>
+            {
+                var _ = new CloudEvent(json);
+            };
 
             act.Should().ThrowExactly<CloudEventValidationException>().WithMessage("'data_base64' must have a valid base-64 encoded binary value.");
         }
@@ -391,7 +415,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var binaryData = new byte[] { 1, 2, 3, 4 };
             var json = $"{{\"data_base64\":\"{Convert.ToBase64String(binaryData)}\",\"data\":{data}}}";
 
-            Action act = () => new CloudEvent(json);
+            Action act = () =>
+            {
+                var _ = new CloudEvent(json);
+            };
 
             act.Should().ThrowExactly<CloudEventValidationException>().WithMessage("'data_base64' and 'data' cannot both have values.");
         }
@@ -405,7 +432,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var json = $"{{\"customattribute\":{attributeValue}}}";
 
-            Action act = () => new CloudEvent(json);
+            Action act = () =>
+            {
+                var _ = new CloudEvent(json);
+            };
 
             act.Should().ThrowExactly<CloudEventValidationException>().WithMessage("Invalid value for 'customattribute' member*");
         }

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -916,7 +916,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             senderMessage.Headers.Add(CloudEvent.TypeAttribute, "MyType");
             senderMessage.Headers.Add(CloudEvent.TimeAttribute, DateTime.UtcNow);
 
-            Action act = () => TestCloudEvent.Validate(senderMessage);
+            Action act = () => CloudEvent.Validate(senderMessage);
 
             act.Should().NotThrow();
         }
@@ -932,7 +932,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             senderMessage.Headers.Add(CloudEvent.TypeAttribute, "MyType");
             senderMessage.Headers.Add(CloudEvent.TimeAttribute, DateTime.UtcNow.ToString("O"));
 
-            Action act = () => TestCloudEvent.Validate(senderMessage);
+            Action act = () => CloudEvent.Validate(senderMessage);
 
             act.Should().NotThrow();
         }
@@ -953,7 +953,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var mockProtocolBinding = new Mock<IProtocolBinding>();
             mockProtocolBinding.Setup(m => m.GetHeaderName(It.IsAny<string>())).Returns<string>(header => "test-" + header);
 
-            Action act = () => TestCloudEvent.Validate(senderMessage, mockProtocolBinding.Object);
+            Action act = () => CloudEvent.Validate(senderMessage, mockProtocolBinding.Object);
 
             act.Should().NotThrow();
         }
@@ -963,7 +963,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Null senderMessage
 
-            Action act = () => TestCloudEvent.Validate(null!);
+            Action act = () => CloudEvent.Validate(null!);
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*senderMessage*");
         }
@@ -981,7 +981,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             senderMessage.Headers.Add(CloudEvent.TypeAttribute, "MyType");
             senderMessage.Headers.Add(CloudEvent.TimeAttribute, DateTime.UtcNow);
 
-            Action act = () => TestCloudEvent.Validate(senderMessage);
+            Action act = () => CloudEvent.Validate(senderMessage);
 
             act.Should().ThrowExactly<CloudEventValidationException>();
         }
@@ -1001,7 +1001,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var mockProtocolBinding = new Mock<IProtocolBinding>();
             mockProtocolBinding.Setup(m => m.GetHeaderName(It.IsAny<string>())).Returns<string>(header => "test-" + header);
 
-            Action act = () => TestCloudEvent.Validate(senderMessage, mockProtocolBinding.Object);
+            Action act = () => CloudEvent.Validate(senderMessage, mockProtocolBinding.Object);
 
             act.Should().NotThrow();
 
@@ -1020,7 +1020,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             senderMessage.Headers.Add(CloudEvent.TypeAttribute, "MyType");
             senderMessage.Headers.Add(CloudEvent.TimeAttribute, DateTime.UtcNow);
 
-            Action act = () => TestCloudEvent.Validate(senderMessage);
+            Action act = () => CloudEvent.Validate(senderMessage);
 
             act.Should().ThrowExactly<CloudEventValidationException>();
         }
@@ -1037,7 +1037,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             senderMessage.Headers.Add(CloudEvent.SourceAttribute, new Uri("http://MySource"));
             senderMessage.Headers.Add(CloudEvent.TimeAttribute, DateTime.UtcNow);
 
-            Action act = () => TestCloudEvent.Validate(senderMessage);
+            Action act = () => CloudEvent.Validate(senderMessage);
 
             act.Should().ThrowExactly<CloudEventValidationException>();
         }
@@ -1057,7 +1057,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var mockProtocolBinding = new Mock<IProtocolBinding>();
             mockProtocolBinding.Setup(m => m.GetHeaderName(It.IsAny<string>())).Returns<string>(header => "test-" + header);
 
-            Action act = () => TestCloudEvent.Validate(senderMessage, mockProtocolBinding.Object);
+            Action act = () => CloudEvent.Validate(senderMessage, mockProtocolBinding.Object);
 
             act.Should().NotThrow();
 
@@ -1102,11 +1102,5 @@ namespace RockLib.Messaging.CloudEvents.Tests
         }
 
         #endregion
-
-        private class TestCloudEvent : CloudEvent
-        {
-            public static new void Validate(SenderMessage senderMessage, IProtocolBinding? protocolBinding = null) =>
-                CloudEvent.Validate(senderMessage, protocolBinding);
-        }
     }
 }

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -703,9 +703,13 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var jsonString = cloudEvent.ToJson(indent);
 
             if (indent)
+            {
                 jsonString.Should().Contain("\n");
+            }
             else
+            {
                 jsonString.Should().NotContain("\n");
+            }
 
         }
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -158,9 +158,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var cloudEvent = new CloudEvent(receiverMessage);
 
-            cloudEvent.Source.ToString().Should().Be(source);
-            cloudEvent.DataContentType.ToString().Should().Be(dataContentType);
-            cloudEvent.DataSchema.ToString().Should().Be(dataSchema);
+            cloudEvent.Should().NotBeNull();
+            cloudEvent.Source!.ToString().Should().Be(source);
+            cloudEvent.DataContentType!.ToString().Should().Be(dataContentType);
+            cloudEvent.DataSchema!.ToString().Should().Be(dataSchema);
             cloudEvent.Time.ToString("O").Should().Be(time);
         }
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -111,7 +111,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var cloudEvent = new CloudEvent(receiverMessage);
 
-            cloudEvent.SpecVersion.Should().Be("1.0");
+            CloudEvent.SpecVersion.Should().Be("1.0");
             cloudEvent.Id.Should().Be("MyId");
             cloudEvent.Source.Should().BeSameAs(source);
             cloudEvent.Type.Should().Be("MyType");
@@ -130,7 +130,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var cloudEvent = new CloudEvent(receiverMessage);
 
-            cloudEvent.SpecVersion.Should().Be("1.0");
+            CloudEvent.SpecVersion.Should().Be("1.0");
             cloudEvent.Source.Should().BeNull();
             cloudEvent.Type.Should().BeNull();
             cloudEvent.DataContentType.Should().BeNull();

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -1,11 +1,8 @@
 ﻿using FluentAssertions;
 using Moq;
 using Newtonsoft.Json.Linq;
-using RockLib.Messaging.Testing;
 using System;
-using System.Linq;
 using System.Net.Mime;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace RockLib.Messaging.CloudEvents.Tests
@@ -70,7 +67,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             var binaryData = new byte[] { 1, 2, 3, 4 };
 
-            var receiverMessage = new FakeReceiverMessage(binaryData);
+            using var receiverMessage = new FakeReceiverMessage(binaryData);
 
             var cloudEvent = new CloudEvent(receiverMessage);
 
@@ -83,7 +80,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             var stringData = "Hello, world!";
 
-            var receiverMessage = new FakeReceiverMessage(stringData);
+            using var receiverMessage = new FakeReceiverMessage(stringData);
 
             var cloudEvent = new CloudEvent(receiverMessage);
 
@@ -96,7 +93,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // All attributes provided
 
-            var receiverMessage = new FakeReceiverMessage("Hello, world!");
+            using var receiverMessage = new FakeReceiverMessage("Hello, world!");
 
             var source = "http://MySource";
             var dataContentType = "application/mycontenttype";
@@ -129,7 +126,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // No attributes provided
 
-            var receiverMessage = new FakeReceiverMessage("Hello, world!");
+            using var receiverMessage = new FakeReceiverMessage("Hello, world!");
 
             var cloudEvent = new CloudEvent(receiverMessage);
 
@@ -147,7 +144,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Alternate property types provided
 
-            var receiverMessage = new FakeReceiverMessage("Hello, world!");
+            using var receiverMessage = new FakeReceiverMessage("Hello, world!");
 
             var source = new Uri("http://MySource").ToString();
             var dataContentType = new ContentType("application/mycontenttype").ToString();
@@ -172,7 +169,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Additional attributes provided
 
-            var receiverMessage = new FakeReceiverMessage("Hello, world!");
+            using var receiverMessage = new FakeReceiverMessage("Hello, world!");
             receiverMessage.Headers.Add("test-foo", "abc");
             receiverMessage.Headers.Add("test-bar", 123);
 
@@ -190,7 +187,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Non-default protocol binding
 
-            var receiverMessage = new FakeReceiverMessage("Hello, world!");
+            using var receiverMessage = new FakeReceiverMessage("Hello, world!");
             receiverMessage.Headers.Add("foo", "abc");
             receiverMessage.Headers.Add("test-" + CloudEvent.IdAttribute, "MyId");
 
@@ -217,7 +214,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Invalid specversion
 
-            var receiverMessage = new FakeReceiverMessage("Hello, world!");
+            using var receiverMessage = new FakeReceiverMessage("Hello, world!");
             receiverMessage.Headers.Add(CloudEvent.SpecVersionAttribute, "0.0");
 
             Action act = () => new CloudEvent(receiverMessage);

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -437,7 +437,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             var cloudEvent = new CloudEvent();
 
-            cloudEvent.Invoking(evt => evt.Id = null).Should()
+            cloudEvent.Invoking(evt => evt.Id = null!).Should()
                 .ThrowExactly<ArgumentNullException>()
                 .WithMessage("*value*");
         }
@@ -932,7 +932,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Null senderMessage
 
-            Action act = () => TestCloudEvent.Validate(null);
+            Action act = () => TestCloudEvent.Validate(null!);
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*senderMessage*");
         }
@@ -1074,7 +1074,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
         private class TestCloudEvent : CloudEvent
         {
-            public static new void Validate(SenderMessage senderMessage, IProtocolBinding protocolBinding = null) =>
+            public static new void Validate(SenderMessage senderMessage, IProtocolBinding? protocolBinding = null) =>
                 CloudEvent.Validate(senderMessage, protocolBinding);
         }
     }

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -178,8 +178,8 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent(receiverMessage, mockProtocolBinding.Object);
 
             cloudEvent.Attributes.Should().HaveCount(2);
-            cloudEvent.Attributes.Should().ContainKey("foo").WhichValue.Should().Be("abc");
-            cloudEvent.Attributes.Should().ContainKey("bar").WhichValue.Should().Be(123);
+            cloudEvent.Attributes.Should().ContainKey("foo").WhoseValue.Should().Be("abc");
+            cloudEvent.Attributes.Should().ContainKey("bar").WhoseValue.Should().Be(123);
         }
 
         [Fact(DisplayName = "Constructor 3 maps with the specified protocol binding")]
@@ -196,7 +196,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var cloudEvent = new CloudEvent(receiverMessage, mockProtocolBinding.Object);
 
             cloudEvent.Id.Should().Be("MyId");
-            cloudEvent.Headers.Should().ContainKey("foo").WhichValue.Should().Be("abc");
+            cloudEvent.Headers.Should().ContainKey("foo").WhoseValue.Should().Be("abc");
         }
 
         [Fact(DisplayName = "Constructor 3 throws when receiverMessage parameter is null")]
@@ -803,8 +803,8 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var senderMessage = cloudEvent.ToSenderMessage();
 
-            senderMessage.Headers.Should().ContainKey("foo").WhichValue.Should().Be("abc");
-            senderMessage.Headers.Should().ContainKey("bar").WhichValue.Should().Be(123);
+            senderMessage.Headers.Should().ContainKey("foo").WhoseValue.Should().Be("abc");
+            senderMessage.Headers.Should().ContainKey("bar").WhoseValue.Should().Be(123);
         }
 
         [Fact(DisplayName = "ToSenderMessage method Binary Mode applies specified protocol binding to each attribute")]
@@ -829,9 +829,9 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             var senderMessage = cloudEvent.ToSenderMessage();
 
-            senderMessage.Headers.Should().ContainKey("test-" + CloudEvent.IdAttribute).WhichValue.Should().BeSameAs(id);
-            senderMessage.Headers.Should().ContainKey("test-" + CloudEvent.SpecVersionAttribute).WhichValue.Should().Be("1.0");
-            senderMessage.Headers.Should().ContainKey("test-foo").WhichValue.Should().Be("abc");
+            senderMessage.Headers.Should().ContainKey("test-" + CloudEvent.IdAttribute).WhoseValue.Should().BeSameAs(id);
+            senderMessage.Headers.Should().ContainKey("test-" + CloudEvent.SpecVersionAttribute).WhoseValue.Should().Be("1.0");
+            senderMessage.Headers.Should().ContainKey("test-foo").WhoseValue.Should().Be("abc");
         }
 
         [Fact(DisplayName = "ToSenderMessage method Structured Mode renders correctly")]
@@ -851,9 +851,9 @@ namespace RockLib.Messaging.CloudEvents.Tests
             var senderMessage = cloudEvent.ToSenderMessage(structuredMode: true);
 
             senderMessage.Headers.Should().ContainKey(CloudEvent.StructuredModeContentTypeHeader)
-                .WhichValue.Should().Be(CloudEvent.StructuredModeJsonMediaType);
+                .WhoseValue.Should().Be(CloudEvent.StructuredModeJsonMediaType);
             senderMessage.Headers.Should().ContainKey(HeaderNames.MessageId)
-                .WhichValue.Should().Be("MyCoreInternalId");
+                .WhoseValue.Should().Be("MyCoreInternalId");
 
             dynamic json = JObject.Parse(senderMessage.StringPayload);
 
@@ -974,7 +974,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             act.Should().NotThrow();
 
-            senderMessage.Headers.Should().ContainKey("test-" + CloudEvent.IdAttribute).WhichValue.Should().NotBeNull();
+            senderMessage.Headers.Should().ContainKey("test-" + CloudEvent.IdAttribute).WhoseValue.Should().NotBeNull();
         }
 
         [Fact(DisplayName = "Validate method throws given missing Source header")]
@@ -1030,7 +1030,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             act.Should().NotThrow();
 
-            senderMessage.Headers.Should().ContainKey("test-" + CloudEvent.TimeAttribute).WhichValue.Should().NotBeNull();
+            senderMessage.Headers.Should().ContainKey("test-" + CloudEvent.TimeAttribute).WhoseValue.Should().NotBeNull();
         }
 
         #endregion
@@ -1052,10 +1052,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
             SenderMessage senderMessage = mockCloudEvent.Object;
 
             senderMessage.StringPayload.Should().Be("Hello, world!");
-            senderMessage.Headers.Should().ContainKey(CloudEvent.IdAttribute).WhichValue.Should().Be("MyId");
-            senderMessage.Headers.Should().ContainKey(CloudEvent.SourceAttribute).WhichValue.ToString().Should().Be("http://mysource/");
-            senderMessage.Headers.Should().ContainKey(CloudEvent.TypeAttribute).WhichValue.Should().Be("test");
-            senderMessage.Headers.Should().ContainKey("foo").WhichValue.Should().Be("abc");
+            senderMessage.Headers.Should().ContainKey(CloudEvent.IdAttribute).WhoseValue.Should().Be("MyId");
+            senderMessage.Headers.Should().ContainKey(CloudEvent.SourceAttribute).WhoseValue.ToString().Should().Be("http://mysource/");
+            senderMessage.Headers.Should().ContainKey(CloudEvent.TypeAttribute).WhoseValue.Should().Be("test");
+            senderMessage.Headers.Should().ContainKey("foo").WhoseValue.Should().Be("abc");
 
             mockCloudEvent.Verify(m => m.ToSenderMessage(It.IsAny<bool>()), Times.Once());
         }

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -374,11 +374,11 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [InlineData("123.45")]
         [InlineData("{\"foo\":123}")]
         [InlineData("[\"abc\"]")]
-        public void Constructor4SadPath4(string data_base64)
+        public void Constructor4SadPath4(string dataBase64)
         {
             // Invalid data_base64
 
-            var json = $"{{\"data_base64\":{data_base64}}}";
+            var json = $"{{\"data_base64\":{dataBase64}}}";
 
             Action act = () =>
             {

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -55,7 +55,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "Constructor 2 throws is source parameter is null")]
         public void Constructor2SadPath()
         {
-            CloudEvent source = null;
+            CloudEvent source = null!;
 
             Action act = () => new CloudEvent(source);
 
@@ -204,7 +204,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Null receiverMessage
 
-            Action act = () => new CloudEvent((IReceiverMessage)null);
+            Action act = () => new CloudEvent((IReceiverMessage)null!);
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*receiverMessage*");
         }
@@ -324,7 +324,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             // Null jsonFormattedCloudEvent
 
-            Action act = () => new CloudEvent((string)null);
+            Action act = () => new CloudEvent((string)null!);
 
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*jsonFormattedCloudEvent*");
         }
@@ -1063,7 +1063,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "Implicit conversion operator returns null given null cloud event")]
         public void ImplicitConversionOperatorHappyPath2()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             SenderMessage senderMessage = cloudEvent;
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CorrelatedEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CorrelatedEventTests.cs
@@ -31,7 +31,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         {
             var cloudEvent = new CorrelatedEvent();
 
-            cloudEvent.Invoking(evt => evt.CorrelationId = null).Should()
+            cloudEvent.Invoking(evt => evt.CorrelationId = null!).Should()
                 .ThrowExactly<ArgumentNullException>()
                 .WithMessage("*value*");
         }

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CorrelatedEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CorrelatedEventTests.cs
@@ -53,7 +53,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             cloudEvent.Attributes.Should().HaveCount(5);
             cloudEvent.Attributes.Should().ContainKey(CorrelatedEvent.CorrelationIdAttribute)
-                .WhichValue.Should().NotBeNull();
+                .WhoseValue.Should().NotBeNull();
         }
 
         [Fact(DisplayName = "Validate static method does not throw when given valid sender message")]
@@ -113,7 +113,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             CorrelatedEvent.Validate(senderMessage);
 
             senderMessage.Headers.Should().ContainKey(CorrelatedEvent.CorrelationIdAttribute)
-                .WhichValue.Should().NotBeNull();
+                .WhoseValue.Should().NotBeNull();
         }
     }
 }

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CorrelatingExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CorrelatingExtensionsTests.cs
@@ -30,7 +30,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.GetCorrelationId();
 
             cloudEvent.Attributes.Should().ContainKey(CorrelatedEvent.CorrelationIdAttribute)
-                .WhichValue.Should().NotBeNull();
+                .WhoseValue.Should().NotBeNull();
         }
 
         [Fact(DisplayName = "GetCorrelationId extension method throws if cloudEvent parameter is null")]
@@ -51,7 +51,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.SetCorrelationId("MyCorrelationId");
 
             cloudEvent.Attributes.Should().ContainKey(CorrelatedEvent.CorrelationIdAttribute)
-                .WhichValue.Should().Be("MyCorrelationId");
+                .WhoseValue.Should().Be("MyCorrelationId");
         }
 
         [Fact(DisplayName = "SetCorrelationId extension method throws if cloudEvent is null")]

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CorrelatingExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CorrelatingExtensionsTests.cs
@@ -36,7 +36,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "GetCorrelationId extension method throws if cloudEvent parameter is null")]
         public void GetCorrelationIdExtensionMethodSadPath()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.GetCorrelationId();
 
@@ -57,7 +57,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "SetCorrelationId extension method throws if cloudEvent is null")]
         public void SetCorrelationIdExtensionMethodSadPath1()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.SetCorrelationId("MyCorrelationId");
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/Directory.Build.props
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+	</PropertyGroup>
+	<PropertyGroup>
+		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<Authors>Rocket Mortgage</Authors>
+		<Copyright>Copyright 2022 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+		<NoWarn>NU1603,NU1701</NoWarn>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/FakeReceiverMessage.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/FakeReceiverMessage.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RockLib.Messaging.CloudEvents.Tests
+{
+    /// <summary>
+    /// A fake implementation of the <see cref="IReceiverMessage"/> interface that allows
+    /// an application's <see cref="IReceiver"/> message handler implementation to be unit
+    /// tested without requiring a mocking framework.
+    /// </summary>
+    public sealed class FakeReceiverMessage : IReceiverMessage, IDisposable
+    {
+        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+
+        private readonly HeaderDictionary _headerDictionary;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FakeReceiverMessage"/> class.
+        /// </summary>
+        /// <param name="payload">The payload of the fake message.</param>
+        public FakeReceiverMessage(string payload)
+        {
+            var headers = new Dictionary<string, object>();
+            Headers = headers;
+            _headerDictionary = new HeaderDictionary(headers);
+            StringPayload = payload ?? throw new ArgumentNullException(nameof(payload));
+            BinaryPayload = Encoding.UTF8.GetBytes(payload);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FakeReceiverMessage"/> class.
+        /// </summary>
+        /// <param name="payload">The payload of the fake message.</param>
+        public FakeReceiverMessage(byte[] payload)
+        {
+            var headers = new Dictionary<string, object>();
+            Headers = headers;
+            _headerDictionary = new HeaderDictionary(headers);
+            BinaryPayload = payload ?? throw new ArgumentNullException(nameof(payload));
+            StringPayload = Convert.ToBase64String(payload);
+            Headers.Add(HeaderNames.IsBinaryPayload, true);
+        }
+
+        /// <inheritdoc />
+        public string StringPayload { get; }
+
+        /// <inheritdoc />
+#pragma warning disable CA1819 // Properties should not return arrays
+        public byte[] BinaryPayload { get; }
+#pragma warning restore CA1819 // Properties should not return arrays
+
+        /// <summary>
+        /// Gets the headers of the test message.
+        /// </summary>
+        public IDictionary<string, object> Headers { get; }
+
+        HeaderDictionary IReceiverMessage.Headers => _headerDictionary;
+
+        /// <inheritdoc />
+        public bool Handled => HandledBy is not null;
+
+        /// <summary>
+        /// Gets the name of the method (Acknowledge, Rollback, or Reject) that
+        /// handled the test message.
+        /// </summary>
+        public string? HandledBy { get; private set; }
+
+        /// <inheritdoc />
+        public async Task AcknowledgeAsync(CancellationToken cancellationToken)
+        {
+            await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                ThrowIfHandled();
+                SetHandled();
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task RollbackAsync(CancellationToken cancellationToken)
+        {
+            await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                ThrowIfHandled();
+                SetHandled();
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task RejectAsync(CancellationToken cancellationToken)
+        {
+            await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                ThrowIfHandled();
+                SetHandled();
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+
+        private void ThrowIfHandled([CallerMemberName] string? callerMemberName = null)
+        {
+            if (Handled)
+            {
+                throw new InvalidOperationException($"Cannot {callerMemberName} message: the message has already been handled by {HandledBy}.");
+            }
+        }
+
+        private void SetHandled([CallerMemberName] string? callerMemberName = null)
+        {
+            HandledBy = callerMemberName;
+        }
+
+        public void Dispose()
+        {
+            _semaphore.Dispose();
+        }
+    }
+}

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/MockExtensions.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/MockExtensions.cs
@@ -16,14 +16,14 @@ namespace RockLib.Messaging.CloudEvents.Tests
 
             mockProtocolBinding.Setup(m => m.GetAttributeName(It.IsAny<string>(), out It.Ref<bool>.IsAny))
                 .Callback(new GetAttributeNameCallback(TestGetAttributeNameCallback))
-                .Returns(new GetAttributeNameDelegate(TestGetAttributeName));
+                .Returns(new GetAttributeName(TestGetAttributeName));
 
             return mockProtocolBinding;
         }
 
         public delegate void GetAttributeNameCallback(string headerName, out bool isCloudEventAttribute);
 
-        public delegate string GetAttributeNameDelegate(string headerName, out bool isCloudEventAttribute);
+        public delegate string GetAttributeName(string headerName, out bool isCloudEventAttribute);
 
         public static void TestGetAttributeNameCallback(string headerName, out bool isCloudEventAttribute)
         {

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/MockExtensions.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/MockExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Moq;
+using System;
 using System.Text.RegularExpressions;
 
 namespace RockLib.Messaging.CloudEvents.Tests
@@ -7,6 +8,10 @@ namespace RockLib.Messaging.CloudEvents.Tests
     {
         public static Mock<IProtocolBinding> SetupTestProtocolBinding(this Mock<IProtocolBinding> mockProtocolBinding)
         {
+            if (mockProtocolBinding is null)
+            {
+                throw new ArgumentNullException(nameof(mockProtocolBinding));
+            }
             mockProtocolBinding.Setup(m => m.GetHeaderName(It.IsAny<string>())).Returns<string>(header => "test-" + header);
 
             mockProtocolBinding.Setup(m => m.GetAttributeName(It.IsAny<string>(), out It.Ref<bool>.IsAny))

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/PartitioningExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/PartitioningExtensionsTests.cs
@@ -61,7 +61,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.SetPartitionKey("MyPartitionKey");
 
             cloudEvent.Attributes.Should().ContainKey(PartitionedEvent.PartitionKeyAttribute)
-                .WhichValue.Should().Be("MyPartitionKey");
+                .WhoseValue.Should().Be("MyPartitionKey");
         }
 
         [Fact(DisplayName = "SetPartitionKey extension method clears the 'partitionkey' attribute when value is null")]

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/PartitioningExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/PartitioningExtensionsTests.cs
@@ -46,7 +46,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "GetPartitionKey extension throws is cloudEvent is null")]
         public void GetPartitionKeyExtensionMethodSadPath()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.GetPartitionKey();
 
@@ -80,7 +80,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "SetPartitionKey extension throws is cloudEvent is null")]
         public void SetPartitionKeyExtensionMethodSadPath()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.SetPartitionKey("MyPartitionKey");
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/ProtocolBindingsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/ProtocolBindingsTests.cs
@@ -1,7 +1,4 @@
 ﻿using FluentAssertions;
-using RockLib.Messaging.CloudEvents.Partitioning;
-using RockLib.Messaging.Testing;
-using System;
 using Xunit;
 
 namespace RockLib.Messaging.CloudEvents.Tests
@@ -53,7 +50,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "Default field's Bind method 2 does nothing")]
         public void DefaultProtocolBindingBindMethod2HappyPath()
         {
-            var receiverMessage = new FakeReceiverMessage("")
+            using var receiverMessage = new FakeReceiverMessage("")
             {
                 Headers =
                 {
@@ -132,7 +129,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "Kafka field's Bind method 2 remaps 'Kafka.Key' to 'partitionkey'")]
         public void KafkaProtocolBindingBindMethod2HappyPath1()
         {
-            var receiverMessage = new FakeReceiverMessage("")
+            using var receiverMessage = new FakeReceiverMessage("")
             {
                 Headers = { ["Kafka.Key"] = "MyKafkaKey" }
             };

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/RockLib.Messaging.CloudEvents.Tests.csproj
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/RockLib.Messaging.CloudEvents.Tests.csproj
@@ -1,29 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net462;</TargetFrameworks>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="RockLib.UniversalMemberAccessor" Version="1.0.8" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\RockLib.Messaging.CloudEvents\RockLib.Messaging.CloudEvents.csproj" />
-  </ItemGroup>
-
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.5.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Moq" Version="4.17.2" />
+        <PackageReference Include="RockLib.UniversalMemberAccessor" Version="2.0.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    
+    <ItemGroup>
+        <ProjectReference Include="..\..\RockLib.Messaging.CloudEvents\RockLib.Messaging.CloudEvents.csproj" />
+    </ItemGroup>
 </Project>

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/SequencingExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/SequencingExtensionsTests.cs
@@ -46,7 +46,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "GetSequence extension throws is cloudEvent is null")]
         public void GetSequenceExtensionMethodSadPath()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.GetSequence();
 
@@ -80,7 +80,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "SetSequence extension throws is cloudEvent is null")]
         public void SetSequenceExtensionMethodSadPath()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.SetSequence("MySequence");
 
@@ -126,7 +126,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "GetSequenceType extension throws is cloudEvent is null")]
         public void GetSequenceTypeExtensionMethodSadPath()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.GetSequenceType();
 
@@ -160,7 +160,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
         [Fact(DisplayName = "SetSequenceType extension throws is cloudEvent is null")]
         public void SetSequenceTypeExtensionMethodSadPath()
         {
-            CloudEvent cloudEvent = null;
+            CloudEvent cloudEvent = null!;
 
             Action act = () => cloudEvent.SetSequenceType("MySequenceType");
 

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/SequencingExtensionsTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/SequencingExtensionsTests.cs
@@ -61,7 +61,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.SetSequence("MySequence");
 
             cloudEvent.Attributes.Should().ContainKey(SequentialEvent.SequenceAttribute)
-                .WhichValue.Should().Be("MySequence");
+                .WhoseValue.Should().Be("MySequence");
         }
 
         [Fact(DisplayName = "SetSequence extension method clears the 'sequence' attribute when value is null")]
@@ -141,7 +141,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.SetSequenceType("MySequenceType");
 
             cloudEvent.Attributes.Should().ContainKey(SequentialEvent.SequenceTypeAttribute)
-                .WhichValue.Should().Be("MySequenceType");
+                .WhoseValue.Should().Be("MySequenceType");
         }
 
         [Fact(DisplayName = "SetSequenceType extension method clears the 'sequencetype' attribute when value is null")]


### PR DESCRIPTION
## Description

Updated target frameworks to support only net6.0, netcoreapp3.1, and net48.

Added .editorconfig and Directory.Build.props for consistency.

Changed url parameter to Uri type in CloudEvent.ToHttpRequestMessage.

## Type of change: <!-- Choose the highest number that applies -->

This is a breaking change and will be updated version to 2.0.0.

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
