### PR TITLE
Update documentation to note Sender/Receiver creation via Configuration.ObjectFactory

### DIFF
--- a/docs/ForwardingReceiver.md
+++ b/docs/ForwardingReceiver.md
@@ -104,6 +104,7 @@ An equivalent forwarding receiver can be defined in config:
 ```
 
 This forwarding receiver can be created by `MessagingScenarioFactory`:
+Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 
 ```c#
 IReceiver receiver = MessagingScenarioFactory.CreateReceiver("MyForwardingReceiver");

--- a/docs/Http.md
+++ b/docs/Http.md
@@ -43,7 +43,7 @@ MessagingScenarioFactory can be configured with an `HttpClientSender` named "com
 // Instances should be disposed before the application exits.
 
 // MessagingScenarioFactory uses the above JSON configuration to create an HttpClientSender
-/ Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 ISender sender = MessagingScenarioFactory.CreateSender("commands");
 
 // HttpClientSender can also be instantiated directly:

--- a/docs/Http.md
+++ b/docs/Http.md
@@ -42,7 +42,8 @@ MessagingScenarioFactory can be configured with an `HttpClientSender` named "com
 // long-lived. They are thread-safe, so you can use a single instance throughout your application.
 // Instances should be disposed before the application exits.
 
-// MessagingScenarioFactory uses the above JSON configuration to create an HttpClientSender:
+// MessagingScenarioFactory uses the above JSON configuration to create an HttpClientSender
+/ Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 ISender sender = MessagingScenarioFactory.CreateSender("commands");
 
 // HttpClientSender can also be instantiated directly:

--- a/docs/Kafka.md
+++ b/docs/Kafka.md
@@ -114,7 +114,8 @@ MessagingScenarioFactory can be configured with an `KafkaSender` named "commands
 // long-lived. They are thread-safe, so you can use a single instance throughout your application.
 // Instances should be disposed before the application exits.
 
-// MessagingScenarioFactory uses the above JSON configuration to create a KafkaSender:
+// MessagingScenarioFactory uses the above JSON configuration to create a KafkaSender
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 ISender sender = MessagingScenarioFactory.CreateSender("commands");
 
 // KafkaSender can also be instantiated directly:
@@ -220,7 +221,8 @@ MessagingScenarioFactory can be configured with an `KafkaReceiver` named "comman
 ```
 
 ```c#
-// MessagingScenarioFactory uses the above JSON configuration to create a KafkaReceiver:
+// MessagingScenarioFactory uses the above JSON configuration to create a KafkaReceiver
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 IReceiver receiver = MessagingScenarioFactory.CreateReceiver("commands");
 
 // KafkaReceiver can also be instantiated directly:

--- a/docs/NamedPipes.md
+++ b/docs/NamedPipes.md
@@ -67,7 +67,8 @@ MessagingScenarioFactory can be configured with a `NamedPipeSender` named "comma
 // long-lived. They are thread-safe, so you can use a single instance throughout your application.
 // Instances should be disposed before the application exits.
 
-// MessagingScenarioFactory uses the above JSON configuration to create a NamedPipeSender:
+// MessagingScenarioFactory uses the above JSON configuration to create a NamedPipeSender
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 ISender sender = MessagingScenarioFactory.CreateSender("commands");
 
 // Use the sender (for good, not evil):
@@ -138,7 +139,8 @@ MessagingScenarioFactory can be configured with a `NamedPipeReceiver` named "com
 ```
 
 ```c#
-// MessagingScenarioFactory uses the above JSON configuration to create a NamedPipeReceiver:
+// MessagingScenarioFactory uses the above JSON configuration to create a NamedPipeReceiver
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 IReceiver receiver = MessagingScenarioFactory.CreateReceiver("commands");
 
 // Start the receiver, passing in a lambda function callback to be invoked when a message is received.

--- a/docs/RabbitMQ.md
+++ b/docs/RabbitMQ.md
@@ -44,7 +44,8 @@ MessagingScenarioFactory can be configured with an `RabbitSender` named "command
 // long-lived. They are thread-safe, so you can use a single instance throughout your application.
 // Instances should be disposed before the application exits.
 
-// MessagingScenarioFactory uses the above JSON configuration to create a RabbitSender:
+// MessagingScenarioFactory uses the above JSON configuration to create a RabbitSender
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 ISender sender = MessagingScenarioFactory.CreateSender("commands");
 
 // RabbitSender can also be instantiated directly:
@@ -108,7 +109,8 @@ MessagingScenarioFactory can be configured with an `RabbitReceiver` named "comma
 ```
 
 ```c#
-// MessagingScenarioFactory uses the above JSON configuration to create a RabbitReceiver:
+// MessagingScenarioFactory uses the above JSON configuration to create a RabbitReceiver
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 IReceiver receiver = MessagingScenarioFactory.CreateReceiver("commands");
 
 // RabbitReceiver can also be instantiated directly:

--- a/docs/SNS.md
+++ b/docs/SNS.md
@@ -71,7 +71,8 @@ MessagingScenarioFactory can be configured with an `SNSSender` named "commands" 
 // long-lived. They are thread-safe, so you can use a single instance throughout your application.
 // Instances should be disposed before the application exits.
 
-// MessagingScenarioFactory uses the above JSON configuration to create a SNSSender:
+// MessagingScenarioFactory uses the above JSON configuration to create a SNSSender
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 ISender sender = MessagingScenarioFactory.CreateSender("commands");
 
 // Use the sender (for good, not evil):

--- a/docs/SQS.md
+++ b/docs/SQS.md
@@ -76,7 +76,8 @@ MessagingScenarioFactory can be configured with an `SQSSender` named "commands" 
 // long-lived. They are thread-safe, so you can use a single instance throughout your application.
 // Instances should be disposed before the application exits.
 
-// MessagingScenarioFactory uses the above JSON configuration to create a SQSSender:
+// MessagingScenarioFactory uses the above JSON configuration to create a SQSSender
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 ISender sender = MessagingScenarioFactory.CreateSender("commands");
 
 // Use the sender (for good, not evil):
@@ -178,7 +179,8 @@ MessagingScenarioFactory can be configured with an `SQSReceiver` named "commands
 ```
 
 ```c#
-// MessagingScenarioFactory uses the above JSON configuration to create a SQSReceiver:
+// MessagingScenarioFactory uses the above JSON configuration to create a SQSReceiver
+// Note that the Value object's properties in the json must map to a valid constructor since CreateSender Creates instances using [RockLib.Configuration.ObjectFactory](https://github.com/RockLib/RockLib.Configuration/tree/main/RockLib.Configuration.ObjectFactory#rocklibconfigurationobjectfactory)
 IReceiver receiver = MessagingScenarioFactory.CreateReceiver("commands");
 
 // Start the receiver, passing in a lambda function callback to be invoked when a message is received.


### PR DESCRIPTION
## Description
Updated the Sender creation documentation to make note that it uses Configuration.ObjectFactory and that the configuration keys and values need to map to a constructor in the Sender type specified.

## Type of change: 

This is a non functional change, documentation only.

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
