### PR TITLE
Corrects wildcard syntax

### DIFF
--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
-####Fixed
+#### Fixed
 - Updated Wildcard syntax with the correct wildcard syntax ".* " which is consistent with the aws cli.
 
 ## 3.0.1 - 2022-03-22

--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+####Fixed
+- Updated Wildcard syntax with the correct wildcard syntax ".* " which is consistent with the aws cli.
+
 ## 3.0.1 - 2022-03-22
 
 #### Fixed

--- a/RockLib.Messaging.SQS/SQSReceiver.cs
+++ b/RockLib.Messaging.SQS/SQSReceiver.cs
@@ -257,7 +257,7 @@ namespace RockLib.Messaging.SQS
                 {
                     MaxNumberOfMessages = MaxMessages,
                     QueueUrl = QueueUrl?.OriginalString,
-                    MessageAttributeNames = new List<string> { "*" },
+                    MessageAttributeNames = new List<string> { ".*" },
                     WaitTimeSeconds = WaitTimeSeconds,
                     AttributeNames = new List<string> { "All" }
                 };

--- a/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
+++ b/Tests/RockLib.Messaging.SQS.Tests/SQSTests.cs
@@ -156,7 +156,7 @@ namespace RockLib.Messaging.SQS.Tests
                 It.Is<ReceiveMessageRequest>(r => r.MaxNumberOfMessages == 3
                     && r.QueueUrl == "http://url.com/foo"
                     && r.MessageAttributeNames.Count == 1
-                    && r.MessageAttributeNames[0] == "*"),
+                    && r.MessageAttributeNames[0] == ".*"),
                 It.IsAny<CancellationToken>()));
 
             Assert.Equal("Hello, world!", receivedMessage);


### PR DESCRIPTION
## Description

I've been trying to read CloudEvents using an SQS Receiver, but I am seeing that the receiver does not hydrate the CloudEvent object, apparently caused by the receiver and its sqs client not being returned any message attributes.

According to [AWS docs](https://docs.aws.amazon.com/cli/latest/reference/sqs/receive-message.html) the correct wildcard syntax is either "All" or ".* " which is consistent with the aws cli. I've been able to verify this locally.

## Type of change: <!-- Choose the highest number that applies -->

2. Bug fix (non-breaking change that fixes an issue)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>