### PR TITLE
RockLib.Messaging.SQS Release 3.0.2-alpha.1

### DIFF
--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## 3.0.2-alpha.1 - 2022-08-10
 
 #### Fixed
 - Updated Wildcard syntax with the correct wildcard syntax ".* " which is consistent with the aws cli.

--- a/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
+++ b/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
@@ -8,12 +8,12 @@
 		<PackageId>RockLib.Messaging.SQS</PackageId>
 		<PackageLicenseFile>LICENSE.md</PackageLicenseFile>
 		<PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
-		<PackageVersion>3.0.1</PackageVersion>
+		<PackageVersion>3.0.2-alpha.1</PackageVersion>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.SQS/CHANGELOG.md.</PackageReleaseNotes>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib messaging sqs</PackageTags>
-		<Version>3.0.1</Version>
+		<Version>3.0.2-alpha.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Description

This creates a 3.0.2-alpha.1 release for RockLib.Messaging.SQS.  The following changes are included:
[Corrects wildcard syntax (](https://github.com/RockLib/RockLib.Messaging/commit/3d1bc718aebbbac12af558463530bdaa96c2e2f0)https://github.com/RockLib/RockLib.Messaging/pull/145[)](https://github.com/RockLib/RockLib.Messaging/commit/3d1bc718aebbbac12af558463530bdaa96c2e2f0)


---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
