### PR TITLE
exposing lifetime parameter for di extensions

### DIFF
--- a/RockLib.Messaging.SQS/DependencyInjection/SQSExtensions.cs
+++ b/RockLib.Messaging.SQS/DependencyInjection/SQSExtensions.cs
@@ -11,6 +11,9 @@ namespace RockLib.Messaging.DependencyInjection
     /// </summary>
     public static class SQSExtensions
     {
+        /// <summary>The default lifetime of messaging services.</summary>
+        private const ServiceLifetime _defaultLifetime = ServiceLifetime.Singleton;
+
         /// <summary>
         /// Adds an <see cref="SQSSender"/> to the service collection.
         /// </summary>
@@ -21,11 +24,12 @@ namespace RockLib.Messaging.DependencyInjection
         /// Whether to create an SQS sender that automatically reloads itself when its
         /// configuration or options change.
         /// </param>
+        /// <param name="lifetime">The <see cref="ServiceLifetime"/> of the receiver.</param>
         /// <returns>A builder allowing the sender to be decorated.</returns>
         public static ISenderBuilder AddSQSSender(this IServiceCollection services, string name,
-            Action<SQSSenderOptions>? configureOptions = null, bool reloadOnChange = true)
+            Action<SQSSenderOptions>? configureOptions = null, bool reloadOnChange = true, ServiceLifetime lifetime = _defaultLifetime)
         {
-            return services.AddSender(name, CreateSQSSender, configureOptions, reloadOnChange);
+            return services.AddSender(name, CreateSQSSender, configureOptions, reloadOnChange, lifetime);
 
             ISender CreateSQSSender(SQSSenderOptions options, IServiceProvider serviceProvider)
             {
@@ -44,10 +48,25 @@ namespace RockLib.Messaging.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="name">The name of the sender.</param>
         /// <param name="configureOptions">A callback for configuring the <see cref="SQSSenderOptions"/>.</param>
+        /// <param name="reloadOnChange">
+        /// Whether to create an SQS sender that automatically reloads itself when its
+        /// configuration or options change.
+        /// </param>
+        /// <returns>A builder allowing the sender to be decorated.</returns>
+        public static ISenderBuilder AddSQSSender(this IServiceCollection services, string name,
+            Action<SQSSenderOptions> configureOptions, bool reloadOnChange) =>
+            services.AddSQSSender(name, configureOptions, reloadOnChange, _defaultLifetime);
+
+        /// <summary>
+        /// Adds an <see cref="SQSSender"/> to the service collection.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="name">The name of the sender.</param>
+        /// <param name="configureOptions">A callback for configuring the <see cref="SQSSenderOptions"/>.</param>
         /// <returns>A builder allowing the sender to be decorated.</returns>
         public static ISenderBuilder AddSQSSender(this IServiceCollection services, string name,
             Action<SQSSenderOptions> configureOptions) =>
-            services.AddSQSSender(name, configureOptions, true);
+            services.AddSQSSender(name, configureOptions, true, ServiceLifetime.Singleton);
 
         /// <summary>
         /// Adds an <see cref="SQSReceiver"/> to the service collection.
@@ -59,11 +78,12 @@ namespace RockLib.Messaging.DependencyInjection
         /// Whether to create an SQS receiver that automatically reloads itself when its
         /// configuration or options change.
         /// </param>
+        /// <param name="lifetime">The <see cref="ServiceLifetime"/> of the receiver.</param>
         /// <returns>A builder allowing the receiver to be decorated.</returns>
         public static IReceiverBuilder AddSQSReceiver(this IServiceCollection services, string name,
-            Action<SQSReceiverOptions>? configureOptions = null, bool reloadOnChange = true)
+            Action<SQSReceiverOptions>? configureOptions = null, bool reloadOnChange = true, ServiceLifetime lifetime = _defaultLifetime)
         {
-            return services.AddReceiver(name, CreateSQSReceiver, configureOptions, reloadOnChange);
+            return services.AddReceiver(name, CreateSQSReceiver, configureOptions, reloadOnChange, lifetime);
 
             IReceiver CreateSQSReceiver(SQSReceiverOptions options, IServiceProvider serviceProvider)
             {
@@ -84,9 +104,24 @@ namespace RockLib.Messaging.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="name">The name of the receiver.</param>
         /// <param name="configureOptions">A callback for configuring the <see cref="SQSReceiverOptions"/>.</param>
+        /// <param name="reloadOnChange">
+        /// Whether to create an SQS receiver that automatically reloads itself when its
+        /// configuration or options change.
+        /// </param>
+        /// <returns>A builder allowing the receiver to be decorated.</returns>
+        public static IReceiverBuilder AddSQSReceiver(this IServiceCollection services, string name,
+            Action<SQSReceiverOptions> configureOptions, bool reloadOnChange) =>
+            services.AddSQSReceiver(name, configureOptions, reloadOnChange, _defaultLifetime);
+
+        /// <summary>
+        /// Adds an <see cref="SQSReceiver"/> to the service collection.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="name">The name of the receiver.</param>
+        /// <param name="configureOptions">A callback for configuring the <see cref="SQSReceiverOptions"/>.</param>
         /// <returns>A builder allowing the receiver to be decorated.</returns>
         public static IReceiverBuilder AddSQSReceiver(this IServiceCollection services, string name,
             Action<SQSReceiverOptions> configureOptions) =>
-            services.AddSQSReceiver(name, configureOptions, true);
+            services.AddSQSReceiver(name, configureOptions, true, _defaultLifetime);
     }
 }

--- a/RockLib.Messaging.SQS/DependencyInjection/SQSExtensions.cs
+++ b/RockLib.Messaging.SQS/DependencyInjection/SQSExtensions.cs
@@ -66,7 +66,7 @@ namespace RockLib.Messaging.DependencyInjection
         /// <returns>A builder allowing the sender to be decorated.</returns>
         public static ISenderBuilder AddSQSSender(this IServiceCollection services, string name,
             Action<SQSSenderOptions> configureOptions) =>
-            services.AddSQSSender(name, configureOptions, true, ServiceLifetime.Singleton);
+            services.AddSQSSender(name, configureOptions, true, _defaultLifetime);
 
         /// <summary>
         /// Adds an <see cref="SQSReceiver"/> to the service collection.

--- a/Tests/RockLib.Messaging.SQS.Tests/DependencyInjectionTests.cs
+++ b/Tests/RockLib.Messaging.SQS.Tests/DependencyInjectionTests.cs
@@ -89,6 +89,27 @@ namespace RockLib.Messaging.SQS.Tests
             sqsSender.SQSClient.Should().BeSameAs(sqsClient);
         }
 
+        [Fact(DisplayName = "Should register SQS sender as transient")]
+        public void SQSSenderRegisterTransient()
+        {
+            var services = new ServiceCollection();
+
+            using var sqsClient = new AmazonSQSClient(RegionEndpoint.USEast2);
+            services.AddSingleton<IAmazonSQS>(sqsClient);
+
+            services.AddSQSSender("mySender", options =>
+            {
+                options.QueueUrl = new Uri("http://example.com");
+            }, lifetime: ServiceLifetime.Transient);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var instance1 = serviceProvider.GetRequiredService<ISender>();
+            var instance2 = serviceProvider.GetRequiredService<ISender>();
+
+            instance1.Should().NotBeSameAs(instance2);
+        }
+
         [Fact]
         public void RetrieveViaSQSReceiver()
         {
@@ -181,6 +202,27 @@ namespace RockLib.Messaging.SQS.Tests
 
             sqsReceiver.Name.Should().Be("myReceiver");
             sqsReceiver.SQSClient.Should().BeSameAs(sqsClient);
+        }
+
+        [Fact(DisplayName = "Should register SQS receiver as transient")]
+        public void SQSReceiverRegisterTransient()
+        {
+            var services = new ServiceCollection();
+
+            using var sqsClient = new AmazonSQSClient(RegionEndpoint.USEast2);
+            services.AddSingleton<IAmazonSQS>(sqsClient);
+
+            services.AddSQSReceiver("myReceiver", options =>
+            {
+                options.QueueUrl = new Uri("http://example.com");
+            }, lifetime: ServiceLifetime.Transient);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var instance1 = serviceProvider.GetRequiredService<IReceiver>();
+            var instance2 = serviceProvider.GetRequiredService<IReceiver>();
+
+            instance1.Should().NotBeSameAs(instance2);
         }
     }
 }

--- a/Tests/RockLib.Messaging.SQS.Tests/DependencyInjectionTests.cs
+++ b/Tests/RockLib.Messaging.SQS.Tests/DependencyInjectionTests.cs
@@ -102,12 +102,9 @@ namespace RockLib.Messaging.SQS.Tests
                 options.QueueUrl = new Uri("http://example.com");
             }, lifetime: ServiceLifetime.Transient);
 
-            var serviceProvider = services.BuildServiceProvider();
-
-            var instance1 = serviceProvider.GetRequiredService<ISender>();
-            var instance2 = serviceProvider.GetRequiredService<ISender>();
-
-            instance1.Should().NotBeSameAs(instance2);
+            services.Should().Contain(s =>
+                s.ServiceType == typeof(ISender) &&
+                s.Lifetime == ServiceLifetime.Transient);
         }
 
         [Fact]
@@ -217,12 +214,9 @@ namespace RockLib.Messaging.SQS.Tests
                 options.QueueUrl = new Uri("http://example.com");
             }, lifetime: ServiceLifetime.Transient);
 
-            var serviceProvider = services.BuildServiceProvider();
-
-            var instance1 = serviceProvider.GetRequiredService<IReceiver>();
-            var instance2 = serviceProvider.GetRequiredService<IReceiver>();
-
-            instance1.Should().NotBeSameAs(instance2);
+            services.Should().Contain(s =>
+                s.ServiceType == typeof(IReceiver) &&
+                s.Lifetime == ServiceLifetime.Transient);
         }
     }
 }


### PR DESCRIPTION
## Description

<!--

1. Include a summary of the feature or issue being fixed, including relevant
   motivation and context.
2. Highlight any sections or parts that you are unsure about, and note any
   compromises you have made while developing this change.
3. Link to the corresponding issue, if one exists.

-->
This exposes the existing lifetime parameter through the DI extensions.
Queues often need to be registered as scoped or transient in order to recover from disconnects, which is observed in long running processes(weeks-months). The underlying `AmazonSQSClient` ends up disposed, while the rocklib wrappers continue to attempt to access it, resulting in exceptions on senders, or nothing on receivers(unless explicitly subscribed to errors).

## Type of change: <!-- Choose the highest number that applies -->

3. New feature (non-breaking change that adds functionality)

## Checklist:

- [x] Have you reviewed your own code? Do you understand every change?
- [x] Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] New and existing unit tests pass locally with these changes?
- [x] Have you made corresponding changes to the documentation?
   - I can if needed, but the underlying parameter is not documented either.
- [x] Will this change require an update to an example project? (if so, create an issue and link to it)
   - No.

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
