### PR TITLE
Bugfix - Add Backpressure to Kafka Receiver

### DIFF
--- a/RockLib.Messaging.Kafka/KafkaReceiver.cs
+++ b/RockLib.Messaging.Kafka/KafkaReceiver.cs
@@ -77,7 +77,7 @@ namespace RockLib.Messaging.Kafka
             builder.SetStatisticsHandler(OnStatisticsEmitted);
 
             _consumer = new Lazy<IConsumer<string, byte[]>>(() => builder.Build());
-            _trackingCollection = CreateBlockingCollection(messageBufferSize);
+            _trackingCollection = CreateMessageTrackingCollection(messageBufferSize);
 
             _schemaIdRequired = schemaIdRequired;
         }
@@ -124,12 +124,12 @@ namespace RockLib.Messaging.Kafka
             builder.SetStatisticsHandler(OnStatisticsEmitted);
 
             _consumer = new Lazy<IConsumer<string, byte[]>>(() => builder.Build());
-            _trackingCollection = CreateBlockingCollection(messageBufferSize);
+            _trackingCollection = CreateMessageTrackingCollection(messageBufferSize);
 
             _schemaIdRequired = schemaIdRequired;
         }
 
-        private static BlockingCollection<KafkaReceiverMessage> CreateBlockingCollection(int size) =>
+        private static BlockingCollection<KafkaReceiverMessage> CreateMessageTrackingCollection(int size) =>
             new(size <= 0 ? int.MaxValue : size);
 
         /// <summary>

--- a/RockLib.Messaging.Kafka/RockLib.Messaging.Kafka.csproj
+++ b/RockLib.Messaging.Kafka/RockLib.Messaging.Kafka.csproj
@@ -11,9 +11,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.Kafka/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib messaging kafka</PackageTags>
-		<PackageVersion>1.0.0</PackageVersion>
+		<PackageVersion>1.0.1</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>1.0.0</Version>
+		<Version>1.0.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>

--- a/docs/Kafka.md
+++ b/docs/Kafka.md
@@ -16,7 +16,7 @@ The first has the following parameters:
   - List of brokers as a CSV list of broker host or host:port.
 - messageTimeoutMs (optional, defaults to 10000)
   - Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
-- statisticsIntervalMs (optional, defaults 0)
+- statisticsIntervalMs (optional, defaults to 0)
   - The statistics emit interval
 
 The second has the following parameters:
@@ -148,8 +148,10 @@ The first has the following parameters:
   - Action to take when there is no initial offset in offset store or the desired offset is out of range: 'smallest','earliest' - automatically reset the offset to the smallest offset, 'largest','latest' - automatically reset the offset to the largest offset, 'error' - trigger an error which is retrieved by consuming messages and checking 'message->err'.
 - schemaIdRequired
   - Should the receiver expect schema information in the message payload
-- statisticsIntervalMs (optional, defaults 0)
+- statisticsIntervalMs (optional, defaults to 0)
   - The statistics emit interval
+- messageBufferSize (optional, defaults to 10)
+  - The number of messages allowed to be queued up in memory, awaiting processing. N - 1 should be the max number of messages the system can comfortably allow duplicate processing.
 
 And the second has the following parameters:
 
@@ -161,6 +163,8 @@ And the second has the following parameters:
   - The configuration used in creation of the Kafka consumer.
 - schemaIdRequired
   - Should the receiver expect schema information in the message payload
+- messageBufferSize (optional, defaults to 10)
+  - The number of messages allowed to be queued up in memory, awaiting processing. N - 1 should be the max number of messages the system can comfortably allow duplicate processing.
 
 ---
 


### PR DESCRIPTION
## Description

This change addresses a couple of different issues. 

1. Out of memory exceptions - in cases where a system has tons of messages to process from a topic regardless of being able to scale, the system can run into out of memory exceptions due to the consuming task not having any backpressure to prevent it from dumping whole partition(s) (and possibly topic) into the tracking collection. 
2. Duplicate message processing - similarly, when a system has tons of messages to process and the number of consumers is less than the number of partitions, upon scaling up the new consumer starts processing the partition it was assigned, but messages it consumes are still in memory of the originally assigned consumer, causing the messages to be processed multiple times. 

## Type of change: Bug fix (non-breaking change that fixes an issue)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
