### PR TITLE
Relaxes specVersion validation

### DIFF
--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -216,7 +216,7 @@ namespace RockLib.Messaging.CloudEvents.Tests
             act.Should().ThrowExactly<ArgumentNullException>().WithMessage("*receiverMessage*");
         }
 
-        [Fact(DisplayName = "Constructor 3 throws when specversion header is not '1.0'")]
+        [Fact(DisplayName = "Constructor 3 throws when specversion header is not '1.0.X'")]
         public void Constructor3SadPath2()
         {
             // Invalid specversion

--- a/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
+++ b/Tests/RockLib.Messaging.CloudEvents.Tests/CloudEventTests.cs
@@ -203,6 +203,21 @@ namespace RockLib.Messaging.CloudEvents.Tests
             cloudEvent.Headers.Should().ContainKey("foo").WhoseValue.Should().Be("abc");
         }
 
+        [Fact(DisplayName = "Constructor 3 accepts specification patch versions '1.0.X'")]
+        public void Constructor3HappyPath8()
+        {
+            // Invalid specversion
+
+            using var receiverMessage = new FakeReceiverMessage("Hello, world!");
+            receiverMessage.Headers.Add(CloudEvent.SpecVersionAttribute, "1.0.2");
+
+            var mockProtocolBinding = new Mock<IProtocolBinding>().SetupTestProtocolBinding();
+
+            var cloudEvent = new CloudEvent(receiverMessage, mockProtocolBinding.Object);
+
+            cloudEvent.Headers.Should().ContainKey(CloudEvent.SpecVersionAttribute).WhoseValue.Should().Be("1.0.2");
+        }
+        
         [Fact(DisplayName = "Constructor 3 throws when receiverMessage parameter is null")]
         public void Constructor3SadPath1()
         {


### PR DESCRIPTION
## Description
[Related Issue](https://github.com/RockLib/RockLib.Messaging/issues/166)

This tries to relax validation when interpreting data as a cloud event to allow for specVersion patch versions 1.0.1 and 1.0.2, which are compatible with 1.0 to be treated as if they were 1.0.

## Type of change: <!-- Choose the highest number that applies -->

2. Bug fix (non-breaking change that fixes an issue)
