### PR TITLE
upgrade RockLib.Messaging.Kafka to reference Confluent.Kafka 2.1.0 #179

### DIFF
--- a/RockLib.Messaging.Kafka/CHANGELOG.md
+++ b/RockLib.Messaging.Kafka/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 - Updated Confluent.Kafka package reference to `2.1.0`
+- Updated Newtonsoft.Json package reference to '13.0.3'
 
 #### Upgrade Considerations [from Confluent.Kafka](https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/CHANGELOG.md#upgrade-considerations)
 - OpenSSL 3.0.x upgrade in librdkafka requires a major version bump, as some legacy ciphers need to be explicitly configured to continue working, but it is highly recommended NOT to use them. The rest of the API remains backward compatible.

--- a/RockLib.Messaging.Kafka/CHANGELOG.md
+++ b/RockLib.Messaging.Kafka/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0-alpha1 - 2023-05-03
+
+#### Changed
+- Updated Confluent.Kafka package reference to `2.1.0`
+
+#### Upgrade Considerations [from Confluent.Kafka](https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/CHANGELOG.md#upgrade-considerations)
+- OpenSSL 3.0.x upgrade in librdkafka requires a major version bump, as some legacy ciphers need to be explicitly configured to continue working, but it is highly recommended NOT to use them. The rest of the API remains backward compatible.
+
 ## 1.0.3 - 2023-02-27
 
 #### Changed

--- a/RockLib.Messaging.Kafka/RockLib.Messaging.Kafka.csproj
+++ b/RockLib.Messaging.Kafka/RockLib.Messaging.Kafka.csproj
@@ -11,9 +11,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.Kafka/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib messaging kafka</PackageTags>
-		<PackageVersion>1.0.3</PackageVersion>
+		<PackageVersion>2.0.0-alpha1</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>1.0.3</Version>
+		<Version>2.0.0-alpha1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -27,7 +27,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-		<PackageReference Include="Confluent.Kafka" Version="1.8.2" />
+		<PackageReference Include="Confluent.Kafka" Version="2.1.0" />
 		<PackageReference Include="RockLib.Messaging" Version="3.0.1" />
 		<PackageReference Include="RockLib.Reflection.Optimized" Version="2.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/RockLib.Messaging.Kafka/RockLib.Messaging.Kafka.csproj
+++ b/RockLib.Messaging.Kafka/RockLib.Messaging.Kafka.csproj
@@ -30,6 +30,6 @@
 		<PackageReference Include="Confluent.Kafka" Version="2.1.0" />
 		<PackageReference Include="RockLib.Messaging" Version="3.0.1" />
 		<PackageReference Include="RockLib.Reflection.Optimized" Version="2.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Upgraded RockLib.Messaging.Kafka to reference Confluent.Kafka 2.1.0.

Please note: Confluent.Kafka 2.0.2 contains a breaking change. [Read more here](https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/CHANGELOG.md#upgrade-considerations)

## Type of change: 4. Breaking change (fix or feature that could cause existing functionality to not work as expected)