### PR TITLE
Reverting SNS and SQS to alpha.1 versions

### DIFF
--- a/Examples/Example.Messaging.SNS/Example.Messaging.SNS.csproj
+++ b/Examples/Example.Messaging.SNS/Example.Messaging.SNS.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-		<PackageReference Include="RockLib.Messaging.SNS" Version="3.0.0" />
-		<PackageReference Include="RockLib.Messaging.SQS" Version="4.0.0" />
+		<PackageReference Include="RockLib.Messaging.SNS" Version="3.0.0-alpha.1" />
+		<PackageReference Include="RockLib.Messaging.SQS" Version="4.0.0-alpha.1" />
 	</ItemGroup>
 </Project>

--- a/Examples/Example.Messaging.SQS/Example.Messaging.SQS.csproj
+++ b/Examples/Example.Messaging.SQS/Example.Messaging.SQS.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="RockLib.Messaging.SQS" Version="4.0.0" />
+		<PackageReference Include="RockLib.Messaging.SQS" Version="4.0.0-alpha.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Example.Common\Example.Common.csproj" />

--- a/RockLib.Messaging.SNS/CHANGELOG.md
+++ b/RockLib.Messaging.SNS/CHANGELOG.md
@@ -5,11 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 3.0.0 - 2024-03-04
-
-#### Changed
-- Finalized 3.0.0 release.
-
 ## 3.0.0-alpha.1 - 2024-02-28
 
 #### Changed

--- a/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
+++ b/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
@@ -12,9 +12,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.SNS/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib messaging sns</PackageTags>
-		<PackageVersion>3.0.0</PackageVersion>
+		<PackageVersion>3.0.0-alpha.1</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.0.0</Version>
+		<Version>3.0.0-alpha.1</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -5,11 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 4.0.0 - 2024-03-04
-
-#### Changed
-- Finalized 4.0.0 version.
-
 ## 4.0.0-alpha.1 - 2024-02-28
 
 #### Changed

--- a/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
+++ b/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
@@ -9,12 +9,12 @@
 		<PackageId>RockLib.Messaging.SQS</PackageId>
 		<PackageLicenseFile>LICENSE.md</PackageLicenseFile>
 		<PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
-		<PackageVersion>4.0.0</PackageVersion>
+		<PackageVersion>4.0.0-alpha.1</PackageVersion>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.SQS/CHANGELOG.md.</PackageReleaseNotes>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib messaging sqs</PackageTags>
-		<Version>4.0.0</Version>
+		<Version>4.0.0-alpha.1</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
## Description

We should not have release final versions of SQS and SNS, so reverting the versions to alpha.1.

## Type of change:

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
