### PR TITLE
update RockLib.Messaging.SNS to 3.0.0

### DIFF
--- a/RockLib.Messaging.SNS/CHANGELOG.md
+++ b/RockLib.Messaging.SNS/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 3.0.0-alpha.2 - 2024-03-07
+## 3.0.0 - 2024-05-16
+
+#### Changed
+- Add logic to retrieve `messageGroupId` and `messageDeduplicationId` from the `SenderMessage` header and assign them to `PublishMessage.MessageGroupId` and `PublishMessage.MessageDeduplicationId` respectively
+
+## 3.0.0-alpha.2 - 2024-05-16
 
 #### Changed
 - Add logic to retrieve `messageGroupId` and `messageDeduplicationId` from the `SenderMessage` header and assign them to `PublishMessage.MessageGroupId` and `PublishMessage.MessageDeduplicationId` respectively

--- a/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
+++ b/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
@@ -12,9 +12,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.SNS/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib messaging sns</PackageTags>
-		<PackageVersion>3.0.0-alpha.2</PackageVersion>
+		<PackageVersion>3.0.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.0.0-alpha.2</Version>
+		<Version>3.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
## Description

This change implements a MessageGroupId and a MessageDeduplicationId for RockLib.Messaging.SNS.

## Type of change: 
3. New feature (non-breaking change that adds functionality)