### PR TITLE
Update RockLib.Messaging.SNS to v3.1.0

### DIFF
--- a/RockLib.Messaging.SNS/CHANGELOG.md
+++ b/RockLib.Messaging.SNS/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.0 - 2024-05-17
+
+#### Changed
+- Bumping version number because 3.0.0 was already published to NuGet but had been unlisted.
+
 ## 3.0.0 - 2024-05-16
 
 #### Changed

--- a/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
+++ b/RockLib.Messaging.SNS/RockLib.Messaging.SNS.csproj
@@ -12,9 +12,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.SNS/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib messaging sns</PackageTags>
-		<PackageVersion>3.0.0</PackageVersion>
+		<PackageVersion>3.1.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.0.0</Version>
+		<Version>3.1.0</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
## Description
Due to a versioning conflict in NuGet, this version needs bumped in order to be published.