### PR TITLE
Release RockLib.Messaging.SQS 4.1.0

### DIFF
--- a/RockLib.Messaging.SQS/CHANGELOG.md
+++ b/RockLib.Messaging.SQS/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.1.0 - 2024-05-17
+
+#### Changed
+- Bumping version number because 3.0.0 was already published to NuGet but had been unlisted.
+
 ## 4.0.0 - 2024-05-17
 
 #### Changed

--- a/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
+++ b/RockLib.Messaging.SQS/RockLib.Messaging.SQS.csproj
@@ -9,12 +9,12 @@
 		<PackageId>RockLib.Messaging.SQS</PackageId>
 		<PackageLicenseFile>LICENSE.md</PackageLicenseFile>
 		<PackageProjectUrl>https://github.com/RockLib/RockLib.Messaging</PackageProjectUrl>
-		<PackageVersion>4.0.0</PackageVersion>
+		<PackageVersion>4.1.0</PackageVersion>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Messaging/blob/main/RockLib.Messaging.SQS/CHANGELOG.md.</PackageReleaseNotes>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib messaging sqs</PackageTags>
-		<Version>4.0.0</Version>
+		<Version>4.1.0</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
Bumping version number to 4.1.0 because 4.0.0 was already published and later unlisted.