### PR TITLE
Don't wait for the handlers to run before getting more messages from the queue

### DIFF
--- a/RockLib.Messaging.SQS/DependencyInjection/SQSExtensions.cs
+++ b/RockLib.Messaging.SQS/DependencyInjection/SQSExtensions.cs
@@ -92,6 +92,13 @@ namespace RockLib.Messaging.DependencyInjection
                         ? new AmazonSQSClient(RegionEndpoint.GetBySystemName(options.Region))
                         : serviceProvider.GetService<IAmazonSQS>() ?? new AmazonSQSClient());
 
+                if (options.ProcessMessageGroupsConcurrently)
+                {
+                    return new SQSConcurrentReceiver(sqsClient, name, options.QueueUrl!, options.MaxMessages,
+                        options.AutoAcknowledge, options.WaitTimeSeconds, options.UnpackSNS,
+                        options.TerminateMessageVisibilityTimeoutOnRollback);
+                }
+
                 return new SQSReceiver(sqsClient, name, options.QueueUrl!, options.MaxMessages,
                     options.AutoAcknowledge, options.WaitTimeSeconds, options.UnpackSNS,
                     options.TerminateMessageVisibilityTimeoutOnRollback);

--- a/RockLib.Messaging.SQS/DependencyInjection/SQSReceiverOptions.cs
+++ b/RockLib.Messaging.SQS/DependencyInjection/SQSReceiverOptions.cs
@@ -89,5 +89,10 @@ namespace RockLib.Messaging.DependencyInjection
         /// available for queue consumers to process.
         /// </summary>
         public bool TerminateMessageVisibilityTimeoutOnRollback { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to process message groups concurrently.
+        /// </summary>
+        public bool ProcessMessageGroupsConcurrently { get; set; }
     }
 }

--- a/RockLib.Messaging.SQS/SQSConcurrentReceiver.cs
+++ b/RockLib.Messaging.SQS/SQSConcurrentReceiver.cs
@@ -1,0 +1,92 @@
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RockLib.Messaging.SQS;
+
+/// <summary>
+/// An implementation of <see cref="IReceiver"/> that processes messages from SQS in parallel.
+/// </summary>
+public class SQSConcurrentReceiver : SQSReceiver
+{
+    private ulong _messagesBeingProcessedCount;
+    private readonly ManualResetEventSlim _noMessagesBeingProcessed = new(initialState:true);
+    private readonly ManualResetEventSlim _doneReceiving = new(initialState:false);
+
+    /// <inheritdoc />
+    public SQSConcurrentReceiver(string name, Uri queueUrl, string? region = null, int maxMessages = DefaultMaxMessages, bool autoAcknowledge = true, int waitTimeSeconds = DefaultWaitTimeSeconds, bool unpackSNS = false, bool terminateMessageVisibilityTimeoutOnRollback = false)
+        : base(name, queueUrl, region, maxMessages, autoAcknowledge, waitTimeSeconds, unpackSNS, terminateMessageVisibilityTimeoutOnRollback)
+    {
+    }
+
+    /// <inheritdoc />
+    public SQSConcurrentReceiver(string name, Uri queueUrl, string region, int maxMessages, bool autoAcknowledge, int waitTimeSeconds, bool unpackSNS)
+        : base(name, queueUrl, region, maxMessages, autoAcknowledge, waitTimeSeconds, unpackSNS)
+    {
+    }
+
+    /// <inheritdoc />
+    public SQSConcurrentReceiver(IAmazonSQS sqs, string name, Uri queueUrl, int maxMessages = DefaultMaxMessages, bool autoAcknowledge = true, int waitTimeSeconds = DefaultWaitTimeSeconds, bool unpackSNS = false, bool terminateMessageVisibilityTimeoutOnRollback = false) : base(sqs, name, queueUrl, maxMessages, autoAcknowledge, waitTimeSeconds, unpackSNS, terminateMessageVisibilityTimeoutOnRollback)
+    {
+    }
+
+    /// <inheritdoc />
+    public SQSConcurrentReceiver(IAmazonSQS sqs, string name, Uri queueUrl, int maxMessages, bool autoAcknowledge, int waitTimeSeconds, bool unpackSNS) : base(sqs, name, queueUrl, maxMessages, autoAcknowledge, waitTimeSeconds, unpackSNS)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override Task ProcessMessagesAsync(IEnumerable<Message> messages)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        foreach (var message in messages)
+        {
+            _ = HandleMessageAsync();
+
+            async Task HandleMessageAsync()
+            {
+                if (Interlocked.Increment(ref _messagesBeingProcessedCount) == 1)
+                {
+                    _noMessagesBeingProcessed.Reset();
+                }
+
+                try
+                {
+                    await HandleAsync(message).ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (Interlocked.Decrement(ref _messagesBeingProcessedCount) == 0)
+                    {
+                        _noMessagesBeingProcessed.Set();
+                    }
+                }
+            }
+        };
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    protected override void OnDoneReceiving()
+    {
+        _doneReceiving.Set();
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            OnStopRequested();
+            _doneReceiving.Wait();
+            _noMessagesBeingProcessed.Wait();
+
+            _doneReceiving.Dispose();
+            _noMessagesBeingProcessed.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/RockLib.Messaging.SQS/SQSReceiver.cs
+++ b/RockLib.Messaging.SQS/SQSReceiver.cs
@@ -327,8 +327,7 @@ namespace RockLib.Messaging.SQS
                     continue;
                 }
 
-                var tasks = response.Messages.Select(HandleAsync);
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                response.Messages.ForEach(x => _ = HandleAsync(x));
             }
         }
 


### PR DESCRIPTION
## Description

I noticed today, while testing some SQS handler code, that my IO-bound handlers were blocking other messages from being picked up by the SQSReceiver. I see that multiple message grabbed from the same poll request are processed concurrently, but I expect a message handler to process events concurrently.

## Type of change: 2

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

## Checklist:

- [x] Have you reviewed your own code? Do you understand every change?
- [ ] Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
